### PR TITLE
Added calendar deeplink link to the list of deeplink urls

### DIFF
--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -4,7 +4,7 @@ const CssInjector = require('../js/css-injector')
 const path = require('path')
 
 const outlookUrl = 'https://outlook.office.com/mail'
-const deeplinkUrls = ['outlook.live.com/mail/deeplink', 'outlook.office365.com/mail/deeplink', 'outlook.office.com/mail/deeplink']
+const deeplinkUrls = ['outlook.live.com/mail/deeplink', 'outlook.office365.com/mail/deeplink', 'outlook.office.com/mail/deeplink', 'outlook.office.com/calendar/deeplink']
 const outlookUrls = ['outlook.live.com', 'outlook.office365.com', 'outlook.office.com']
 
 class MailWindowController {


### PR DESCRIPTION
This should force calendar deeplinks that are opened to open in a new window so that they won't lock up the application as reported in Issues 55 and 17