### PR TITLE
add nativeWindowOpen to support popout messages

### DIFF
--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -28,7 +28,8 @@ class MailWindowController {
             title: 'Prospect Mail',
             icon: path.join(__dirname, '../../assets/outlook_linux_black.png'),
             webPreferences: {
-                spellcheck: true
+                spellcheck: true,
+                nativeWindowOpen: true
               }
         })
 


### PR DESCRIPTION
This addresses #124 by adding `nativeWindowOpen: true` to the main broswerwindow webPreferences.
This allows the outlook parent window to provide callback information to the child for outlook deeplinks.