### PR TITLE
use isVisible() and change label to reflect

### DIFF
--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -134,7 +134,7 @@ class MailWindowController {
     }
 
     toggleWindow() {
-        if (this.win.isFocused()) {
+        if (this.win.isVisible()) {
             this.win.hide()
         } else {
             this.show()

--- a/src/controller/tray-controller.js
+++ b/src/controller/tray-controller.js
@@ -14,7 +14,7 @@ class TrayController {
         this.tray = new Tray(this.createTrayIcon(''))
 
         const context = Menu.buildFromTemplate([
-            {label: 'Show Me', click: () => this.showHide()},
+            {label: 'Show/Hide', click: () => this.showHide()},
             {label: 'Separator', type: 'separator'},
             {label: 'Window Frame', type: 'checkbox', checked: settings.get('showWindowFrame', true), click: () => this.toggleWindowFrame()},
             {label: 'Quit', click: () => this.cleanupAndQuit()}


### PR DESCRIPTION
This fixes #89 by changing to use `isVisible()` instead of `isFocused()` and updates the menu item to reflect that it will both show and/or hide the window depending on current state.