### PR TITLE
Implement broker based intune SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,13 @@ need to click in "Reload settings" to apply changes.
   "hideOnClose": true,
   "hideOnMinimize": true,
   "startMinimized": false,
-  "customBrowserPath": "microsoft-edge"
+  "customBrowserPath": "microsoft-edge",
+  "auth": {
+    "intune": {
+      "enabled": false,
+      "user": ""
+    }
+  }
 }
 ```
 
@@ -117,6 +123,32 @@ need to click in "Reload settings" to apply changes.
 | `hideOnMinimize`    | Hide to tray when minimizing window                                                          | `true`                            |
 | `startMinimized`    | Start app minimized to tray (also available via tray menu or `--minimized` flag)             | `false`                           |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |
+| `auth.intune.enabled` | Enable Microsoft Intune / Microsoft Identity Broker SSO bridge                             | `false`                           |
+| `auth.intune.user`  | Optional broker account UPN/email to use for Intune SSO. Empty uses the first broker account | `""`                              |
+
+### Microsoft Intune SSO
+
+Prospect Mail can optionally request a PRT SSO credential from Microsoft
+Identity Broker and attach it to Microsoft login requests. Enable it only on an
+Intune-enrolled Linux device:
+
+```json
+{
+  "auth": {
+    "intune": {
+      "enabled": true,
+      "user": "user@company.com"
+    }
+  }
+}
+```
+
+Prerequisites:
+
+- Microsoft Identity Broker is installed and available on D-Bus.
+- The account is enrolled through Intune Company Portal or equivalent.
+- A valid Primary Refresh Token is available for the account.
+- Debug logs can be checked for `[INTUNE_SSO]` messages.
 
 ### Example Configuration for Personal Outlook
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@homebridge/dbus-native": "0.7.4",
         "electron-store": "^8.2.0"
       },
       "devDependencies": {
@@ -305,6 +306,23 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@homebridge/dbus-native": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.4.tgz",
+      "integrity": "sha512-DtX16c/NNT/NJBFgy8qu74z/SZuAaS0GJahKIrS9ZZOYUHDtZYr1B4ZdjQlr+1NT7ZcCk6e84O4lAieiJq0Hsw==",
+      "license": "MIT",
+      "dependencies": {
+        "event-stream": "^4.0.1",
+        "hexy": "^0.4.0",
+        "long": "^5.3.2",
+        "minimist": "^1.2.8",
+        "safe-buffer": "^5.1.2",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "dbus2js": "bin/dbus2js.js"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -1618,6 +1636,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
@@ -1905,6 +1929,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "dev": true,
@@ -2059,6 +2098,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -2311,6 +2356,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexy": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -2647,6 +2704,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -2680,6 +2743,12 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "license": "MIT"
     },
     "node_modules/matcher": {
       "version": "3.0.0",
@@ -2771,7 +2840,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3184,6 +3252,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "dev": true,
@@ -3456,7 +3536,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3488,7 +3567,6 @@
     },
     "node_modules/sax": {
       "version": "1.4.4",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -3627,6 +3705,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "dev": true,
@@ -3650,6 +3740,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "node_modules/string_decoder": {
@@ -3816,6 +3916,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -4011,6 +4117,28 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
+    "@homebridge/dbus-native": "0.7.4",
     "electron-store": "^8.2.0"
   },
   "devDependencies": {
@@ -154,6 +155,7 @@
         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=com.microsoft.identity.broker1",
         "--own-name=org.mpris.MediaPlayer2.chromium.*",
         "--filesystem=xdg-run/tray-icon:create",
         "--env=XDG_SESSION_TYPE=x11"

--- a/src/controller/intune-sso.js
+++ b/src/controller/intune-sso.js
@@ -1,0 +1,228 @@
+const dbus = require("@homebridge/dbus-native");
+
+const BROKER_SERVICE = "com.microsoft.identity.broker1";
+const BROKER_PATH = "/com/microsoft/identity/broker1";
+const BROKER_INTERFACE = "com.microsoft.identity.Broker1";
+const PROTOCOL_VERSION = "0.0";
+const ACCOUNT_CLIENT_ID = "88200948-af09-45a1-9c03-53cdcc75c183";
+const SSO_CLIENT_ID = "d7b530a4-7680-4c23-a8bf-c52c121d2e87";
+const LOG_PREFIX = "[INTUNE_SSO]";
+
+const sessionBus = dbus.sessionBus();
+
+let intuneAccount = null;
+
+function invokeBrokerMethod(methodName, request, correlationId = "") {
+  return new Promise((resolve, reject) => {
+    sessionBus.invoke(
+      {
+        destination: BROKER_SERVICE,
+        path: BROKER_PATH,
+        interface: BROKER_INTERFACE,
+        member: methodName,
+        signature: "sss",
+        body: [PROTOCOL_VERSION, correlationId, JSON.stringify(request)],
+      },
+      (err, result) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve(result);
+      }
+    );
+  });
+}
+
+function extractCookieContent(response) {
+  if (
+    Array.isArray(response.cookieItems) &&
+    response.cookieItems.length > 0 &&
+    response.cookieItems[0].cookieContent
+  ) {
+    return response.cookieItems[0].cookieContent;
+  }
+
+  return response.cookieContent || null;
+}
+
+function getAccountsRequest() {
+  return {
+    clientId: ACCOUNT_CLIENT_ID,
+    redirectUri: "urn:ietf:oob",
+  };
+}
+
+async function getBrokerAccounts() {
+  return invokeBrokerMethod("getAccounts", getAccountsRequest());
+}
+
+async function waitForBrokerReady(retries = 10, delay = 500) {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      await getBrokerAccounts();
+      return;
+    } catch (error) {
+      if (error?.name === "org.freedesktop.DBus.Error.ServiceUnknown") {
+        throw new Error("Microsoft Identity Broker D-Bus service is unavailable");
+      }
+
+      if (attempt === retries) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+function selectBrokerAccount(responseText, configuredUser) {
+  const response = JSON.parse(responseText);
+
+  if (response.error) {
+    console.warn(`${LOG_PREFIX} Broker account query failed`, {
+      errorCode: response.error.code || "unknown",
+    });
+    return;
+  }
+
+  const accounts = Array.isArray(response.accounts) ? response.accounts : [];
+  console.info(`${LOG_PREFIX} Broker accounts returned`, {
+    count: accounts.length,
+    hasConfiguredUser: Boolean(configuredUser),
+  });
+
+  if (accounts.length === 0) {
+    console.warn(`${LOG_PREFIX} No broker accounts found`);
+    return;
+  }
+
+  if (!configuredUser) {
+    intuneAccount = accounts[0];
+    console.info(`${LOG_PREFIX} Using first broker account`);
+    return;
+  }
+
+  const configuredUserLower = configuredUser.toLowerCase();
+  intuneAccount = accounts.find(
+    (account) => account.username?.toLowerCase() === configuredUserLower
+  );
+
+  if (intuneAccount) {
+    console.info(`${LOG_PREFIX} Matching broker account found`);
+  } else if (accounts.length === 1) {
+    intuneAccount = accounts[0];
+    console.warn(`${LOG_PREFIX} Matching broker account missing; using only broker account`);
+  } else {
+    console.warn(`${LOG_PREFIX} Matching broker account missing`);
+  }
+}
+
+function buildPrtSsoCookieRequest(ssoUrl) {
+  return {
+    account: intuneAccount,
+    authParameters: {
+      account: intuneAccount,
+      additionalQueryParametersForAuthorization: {},
+      authority: "https://login.microsoftonline.com/common",
+      authorizationType: 8,
+      clientId: SSO_CLIENT_ID,
+      redirectUri: "https://login.microsoftonline.com/common/oauth2/nativeclient",
+      requestedScopes: ["openid", "profile", "offline_access"],
+      username: intuneAccount.username,
+      uxContextHandle: -1,
+      ssoUrl,
+    },
+    mamEnrollment: false,
+    ssoUrl,
+  };
+}
+
+function safeCallback(callback, requestHeaders) {
+  callback({ requestHeaders });
+}
+
+async function addSsoCookieAsync(detail, callback) {
+  try {
+    const responseText = await invokeBrokerMethod(
+      "acquirePrtSsoCookie",
+      buildPrtSsoCookieRequest(detail.url)
+    );
+    const response = JSON.parse(responseText);
+
+    if (response.error) {
+      console.warn(`${LOG_PREFIX} Credential request failure`, {
+        errorCode: response.error.code || "unknown",
+      });
+      safeCallback(callback, detail.requestHeaders);
+      return;
+    }
+
+    const cookieContent = extractCookieContent(response);
+    if (!cookieContent) {
+      console.warn(`${LOG_PREFIX} Credential response missing cookie content`);
+      safeCallback(callback, detail.requestHeaders);
+      return;
+    }
+
+    detail.requestHeaders["X-Ms-Refreshtokencredential"] = cookieContent;
+    console.info(`${LOG_PREFIX} SSO credential added to request`);
+  } catch (error) {
+    console.warn(`${LOG_PREFIX} Credential request failure`, {
+      error: error.message || error,
+    });
+  }
+
+  safeCallback(callback, detail.requestHeaders);
+}
+
+async function initSso(configuredUser) {
+  intuneAccount = null;
+  console.info(`${LOG_PREFIX} Broker initialization start`, {
+    hasConfiguredUser: Boolean(configuredUser),
+  });
+
+  try {
+    await waitForBrokerReady();
+    const accountsResponse = await getBrokerAccounts();
+    selectBrokerAccount(accountsResponse, configuredUser);
+  } catch (error) {
+    console.warn(`${LOG_PREFIX} Broker unavailable`, {
+      error: error.message || error,
+    });
+  }
+}
+
+function setupUrlFilter(filter) {
+  filter.urls.push("https://login.microsoftonline.com/*");
+}
+
+function isSsoUrl(url) {
+  return (
+    intuneAccount != null &&
+    typeof url === "string" &&
+    url.startsWith("https://login.microsoftonline.com/")
+  );
+}
+
+function addSsoCookie(detail, callback) {
+  if (intuneAccount == null) {
+    safeCallback(callback, detail.requestHeaders);
+    return;
+  }
+
+  addSsoCookieAsync(detail, callback).catch((error) => {
+    console.warn(`${LOG_PREFIX} Credential request failure`, {
+      error: error.message || error,
+    });
+    safeCallback(callback, detail.requestHeaders);
+  });
+}
+
+module.exports = {
+  initSso,
+  setupUrlFilter,
+  isSsoUrl,
+  addSsoCookie,
+};

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -9,6 +9,7 @@ let deeplinkUrls;
 let safelinksUrls;
 let mailServicesUrls;
 let showWindowFrame;
+let intuneSso;
 
 //Setted by cmdLine to initial minimization
 const initialMinimization = {
@@ -17,7 +18,7 @@ const initialMinimization = {
 
 class MailWindowController {
   constructor() {
-    this.init();
+    this.ready = this.init();
     // Check both command-line flag and settings for initial minimization
     const hasMinimizedFlag = global.cmdLine.indexOf("--minimized") !== -1;
     const startMinimizedSetting = settings.get("startMinimized");
@@ -86,8 +87,9 @@ class MailWindowController {
     }
   }
 
-  init() {
+  async init() {
     this.reloadSettings();
+    intuneSso = null;
 
     // Create the browser window.
     this.win = new BrowserWindow({
@@ -106,6 +108,15 @@ class MailWindowController {
         preload: path.join(__dirname, "preload.js"),
       },
     });
+
+    const auth = settings.get("auth") || {};
+    const intuneConfig = auth.intune || {};
+    if (intuneConfig.enabled) {
+      const intuneUser =
+        typeof intuneConfig.user === "string" ? intuneConfig.user.trim() : "";
+      intuneSso = require("./intune-sso");
+      await intuneSso.initSso(intuneUser);
+    }
 
     const isDev = process.env.NODE_ENV === "development" || !app.isPackaged;
 
@@ -136,6 +147,23 @@ class MailWindowController {
       "Mozilla/5.0 " +
       userAgentOS +
       " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0"; // TODO: Updated Edge version
+
+    const filter = { urls: ["https://*/*"] };
+    if (intuneSso) {
+      intuneSso.setupUrlFilter(filter);
+    }
+
+    this.win.webContents.session.webRequest.onBeforeSendHeaders(
+      filter,
+      (detail, callback) => {
+        if (intuneSso?.isSsoUrl(detail.url)) {
+          intuneSso.addSsoCookie(detail, callback);
+          return;
+        }
+
+        callback({ requestHeaders: detail.requestHeaders });
+      }
+    );
 
     // and load the index.html of the app.
     this.win.loadURL(mainMailServiceUrl, {
@@ -354,6 +382,8 @@ class MailWindowController {
   }
 
   toggleWindow() {
+    if (!this.win) return;
+
     console.log("toggleWindow", {
       isFocused: this.win.isFocused(),
       isVisible: this.win.isVisible(),
@@ -366,11 +396,15 @@ class MailWindowController {
     }
   }
   reloadWindow() {
+    if (!this.win) return;
+
     initialMinimization.domReady = false;
     this.win.reload();
   }
 
   show() {
+    if (!this.win) return;
+
     initialMinimization.domReady = false;
 
     // Restore if minimized, otherwise just show

--- a/src/controller/tray-controller.js
+++ b/src/controller/tray-controller.js
@@ -144,7 +144,7 @@ class TrayController {
     this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
     global.preventAutoCloseApp = true;
     this.mailController.win.destroy();
-    this.mailController.init();
+    this.mailController.ready = this.mailController.init();
   }
   toggleHideOnClose() {
     let orivalue = settings.get("hideOnClose");

--- a/src/main.js
+++ b/src/main.js
@@ -41,8 +41,8 @@ class ProspectMail {
     // This method will be called when Electron has finished
     // initialization and is ready to create browser windows.
     // Some APIs can only be used after this event occurs.
-    app.on("ready", () => {
-      this.createControllers();
+    app.on("ready", async () => {
+      await this.createControllers();
     });
     // Quit when all windows are closed.
     app.on("window-all-closed", () => {
@@ -54,8 +54,9 @@ class ProspectMail {
     });
   }
 
-  createControllers() {
+  async createControllers() {
     this.mailController = new MailWindowController();
+    await this.mailController.ready;
     this.trayController = new TrayController(this.mailController);
   }
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -29,7 +29,13 @@ const settings = new Store({
     hideOnClose: true,
     hideOnMinimize: true,
     startMinimized: false,
-    customBrowserPath: undefined
+    customBrowserPath: undefined,
+    auth: {
+      intune: {
+        enabled: false,
+        user: ""
+      }
+    }
   }
 });
 


### PR DESCRIPTION
Add optional Microsoft Intune / Microsoft Identity Broker SSO support to Prospect Mail, similar to the implementation in `teams-for-linux`.

ref: https://github.com/IsmaelMartinez/teams-for-linux/blob/main/docs-site/docs/development/adr/012-intune-sso-broker-compatibility.md

When enabled, Prospect Mail will:

- Discover an enrolled Microsoft account through Microsoft Identity Broker over D-Bus.
- Intercept Microsoft login requests to `https://login.microsoftonline.com/*`.
- Request a PRT SSO credential from the broker.
- Add the credential to the outgoing login request as `X-Ms-Refreshtokencredential`.
- Continue normal login behavior if the broker is unavailable or no account matches.