### PR TITLE
fix: publish snap to beta channel + docs refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ all contributors.
 
 Before you begin:
 
-- Install [git](https://git-scm.com/) and [Node.js](https://nodejs.org/) v22.x LTS
+- Install [git](https://git-scm.com/) and [Node.js](https://nodejs.org/) v24.x LTS
 - Read the [README.md](README.md)
 - Check existing [issues](https://github.com/julian-alarcon/prospect-mail/issues)
   and [pull requests](https://github.com/julian-alarcon/prospect-mail/pulls) to
@@ -213,31 +213,48 @@ Example: `0.6.0-beta2`
 
 ### Creating a New Release
 
-```shell
-# Bump version (choose one):
-npm version prerelease --preid=beta  # Auto-increment beta version
-npm version 1.2.1                    # Stable release
+Always bump the version with `npm version` (never edit `package.json` by hand):
+it updates `package.json` and `package-lock.json`, creates the commit, and
+creates the matching git tag in one step. The tree must be clean first.
 
-# Push changes and tag (npm version creates tag automatically)
-git push
-git push origin --tags
+Use explicit version strings so the tag matches the `MAJOR.MINOR.PATCH-beta#`
+convention. A typical cycle ships a beta first, then the stable release:
+
+```shell
+# 1. Beta (from a clean, up-to-date main)
+git checkout main && git pull
+npm version 1.3.0-beta1
+git push --follow-tags        # pushes the commit and the tag together
+
+# 2. After testing the beta, cut the stable release
+git checkout main && git pull
+npm version 1.3.0
+git push --follow-tags
 ```
 
-Open a Pull Request for the version update. After merge, the tag push triggers
-automated release.
+> If `main` is protected (requires PRs), run `npm version` on a short-lived
+> branch, open a PR, and push the tag after merge. The tag is what triggers the
+> release.
 
-6. **Automated release process**: When the tag is pushed, GitHub Actions will automatically:
-   - Generate release notes from commits (see `.github/release-notes-from-commits.yml`)
-   - Create GitHub release with changelog
-   - Build for Linux (x64, arm64): AppImage, deb, pacman, rpm, snap, flatpak, tar.gz
-   - Build for macOS (arm64, x64): dmg
-   - Build for Windows (x64, arm64): exe, msi
-   - Attach artifacts to GitHub release
-   - Publish snap to Snap Store (beta channel)
+When the tag is pushed, GitHub Actions automatically:
 
-7. **Promote Snap Store release**:
-   - Go to [Snap Store releases](https://snapcraft.io/prospect-mail/releases)
-   - Move the release from beta to stable channel
+- Generates release notes from commit prefixes (see `.github/release.yml`)
+- Creates the GitHub release (marked pre-release for `-beta` tags)
+- Builds Linux (x64, arm64): AppImage, deb, pacman, rpm, snap, flatpak, tar.gz
+- Builds macOS (arm64, x64): dmg
+- Builds Windows (x64, arm64): exe, msi
+- Attaches all artifacts to the GitHub release
+- Publishes the snap to the Snap Store **beta** channel
+
+Snap always publishes to the **beta** channel (configured in `package.json`),
+including stable version tags. To ship a stable snap, promote it manually:
+
+- Go to [Snap Store releases](https://snapcraft.io/prospect-mail/releases)
+- Move the release from **beta** to **stable**
+
+> The Snap Store publish step needs a valid `SNAPCRAFT_TOKEN` repository secret.
+> These tokens expire; if the release job fails with "Exported credentials are
+> no longer valid", rotate it (see [Manual Snap Store Release](#manual-snap-store-release)).
 
 ### Automatic Changelog Generation
 
@@ -265,12 +282,32 @@ Note: For breaking changes, you can use the `!` suffix with any commit type
 
 ### Manual Snap Store Release
 
-If needed, you can manually release to the Snap Store:
+If needed, you can manually upload and release a snap:
 
 ```shell
 snapcraft login
-snapcraft upload --release=edge prospect-mail_x.y.z_arch.snap
+snapcraft upload --release=beta prospect-mail_x.y.z_arch.snap
 ```
+
+#### Rotating the CI Snap Store token
+
+The automated release uses the `SNAPCRAFT_TOKEN` repository secret. Store tokens
+expire, so regenerate and update it when a release job fails to publish:
+
+```shell
+snapcraft login
+snapcraft export-login \
+  --channels beta,stable \
+  --acls package_access,package_push,package_release \
+  --expires 2027-12-31 \
+  snapcraft-token.txt
+gh secret set SNAPCRAFT_TOKEN --repo julian-alarcon/prospect-mail < snapcraft-token.txt
+rm snapcraft-token.txt
+```
+
+> Update the secret **before** re-running a failed job. GitHub injects secrets
+> when a job starts, so a re-run that began before the update still uses the old
+> token.
 
 ## Reporting Issues
 
@@ -310,9 +347,9 @@ and include:
 
 ### Core Components
 
-- **Node.js**: v22.x LTS
+- **Node.js**: v24.x LTS
 - **npm**: (comes with Node.js)
-- **Electron**: v39.x
+- **Electron**: v42.x (pinned; see `src/controller/tray-controller.js` for why)
 - **electron-builder**: v26.x
 - **electron-store**: v8.2.0
 
@@ -320,8 +357,9 @@ and include:
 
 #### Linux
 
-- Snap builds use `core22` base with strict confinement
-- Multiple package formats supported: AppImage, deb, pacman, rpm, snap, tar.gz
+- Snap builds use `core24` base with strict confinement (built via LXD)
+- Flatpak builds use the `25.08` runtime
+- Multiple package formats supported: AppImage, deb, pacman, rpm, snap, flatpak, tar.gz
 - Architectures: x64, arm64
 - Requires `libarchive-tools` for pacman builds
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Microsoft/Office 365 accounts, don't use it for personal Outlook.com accounts.
 
 Available for Linux, Windows (10+) and macOS.
 
+> [!IMPORTANT]
 > This project has NO DIRECT AFFILIATION with Microsoft, Microsoft 365 or any
 > product made by Microsoft.
 
@@ -83,8 +84,10 @@ need to click in "Reload settings" to apply changes.
 
 ```json
 {
-  "urlMainWindow": "https://outlook.office.com/mail",
+  "urlMainWindow": "https://outlook.cloud.microsoft/mail",
   "urlsInternal": [
+    "outlook.cloud.microsoft/mail/deeplink",
+    "outlook.cloud.microsoft/calendar/deeplink",
     "outlook.live.com/mail/deeplink",
     "outlook.office365.com/mail/deeplink",
     "outlook.office.com/mail/deeplink",
@@ -92,11 +95,13 @@ need to click in "Reload settings" to apply changes.
     "to-do.office.com/tasks"
   ],
   "urlsExternal": [
+    "outlook.cloud.microsoft",
     "outlook.live.com",
     "outlook.office365.com",
     "outlook.office.com"
   ],
   "safelinksUrls": [
+    "outlook.cloud.microsoft/mail/safelink.html",
     "outlook.office.com/mail/safelink.html",
     "safelinks.protection.outlook.com"
   ],
@@ -113,7 +118,7 @@ need to click in "Reload settings" to apply changes.
 
 | Setting             | Description                                                                                  | Default                           |
 | ------------------- | -------------------------------------------------------------------------------------------- | --------------------------------- |
-| `urlMainWindow`     | Main Outlook service URL to load                                                             | `https://outlook.office.com/mail` |
+| `urlMainWindow`     | Main Outlook service URL to load                                                             | `https://outlook.cloud.microsoft/mail` |
 | `urlsInternal`      | Array of URL patterns for deeplinks that open in new app windows                             | See example above                 |
 | `urlsExternal`      | Array of URL patterns for Outlook/Microsoft 365 services that open in the main window       | See example above                 |
 | `safelinksUrls`     | Array of URL patterns for Microsoft Safe Links that open in external browser                 | See example above                 |
@@ -123,6 +128,12 @@ need to click in "Reload settings" to apply changes.
 | `startMinimized`    | Start app minimized to tray (also available via tray menu or `--minimized` flag)             | `false`                           |
 | `disableUnreadNotifications` | Disable the "new messages" desktop notification while keeping calendar reminders enabled (also available via tray menu) | `false`                  |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |
+
+> [!NOTE]
+> `outlook.cloud.microsoft` is Microsoft's unified-domain Outlook host and is
+> now the default. The legacy `office.com` / `office365.com` / `live.com` hosts
+> still work. Existing installs keep their saved `urlMainWindow`; use "Restore
+> Default Settings" in the tray menu to adopt the new default.
 
 ### Example Configuration for Personal Outlook
 
@@ -145,10 +156,10 @@ This configuration will let you use Prospect with personal Outlook.com account:
 The main software architecture components and their versions are this:
 
 - [Node.js](https://nodejs.org/en/about/previous-releases#release-schedule)
-version: 22.x LTS
+version: 24.x LTS
 - [npm](https://docs.npmjs.com/) (comes with Node.js)
 - [electron](https://www.electronjs.org/docs/latest/tutorial/electron-timelines)
-version: 39.x
+version: 42.x (pinned)
 - [electron-builder](https://www.electron.build/) version: 26.x
 - [electron-store](https://github.com/sindresorhus/electron-store)
   version: 8.2.0
@@ -175,8 +186,8 @@ Build the application for Linux
 npm run dist:linux
 ```
 
-This will build an AppImage, deb, flatpak and snap files in the dist folder.
-These files can be run in most popular Linux distributions.
+This will build AppImage, deb, pacman, rpm, flatpak, snap and tar.gz files in
+the dist folder. These files can be run in most popular Linux distributions.
 
 You can specify a specific build type:
 
@@ -186,7 +197,7 @@ npm run dist:linux:flatpak
 npm run dist:linux:appimage
 ```
 
-Build the application for Mac (It works in versions 10.14 and 10.15)
+Build the application for macOS (arm64 and x64)
 
 ```shell
 npm run dist:mac

--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
     },
     "snapcraft": {
       "base": "core24",
+      "publish": [
+        {
+          "provider": "snapStore",
+          "channels": "beta"
+        }
+      ],
       "core24": {
         "confinement": "strict",
         "grade": "stable",
@@ -128,13 +134,7 @@
         ],
         "environment": {
           "TMPDIR": "$XDG_RUNTIME_DIR"
-        },
-        "publish": [
-          {
-            "provider": "snapStore",
-            "channels": "beta"
-          }
-        ]
+        }
       }
     },
     "flatpak": {


### PR DESCRIPTION
## Summary

Two changes needed before re-cutting the 1.3.0 beta:

### `fix:` snap publishes to wrong channel (root cause of failed release)
The v1.3.0-beta1 release job failed with:
> invalid-channel-permission: Macaroon channel restrictions (beta, stable) do not allow release to edge.

The `publish` block with `channels: beta` was nested under `build.snapcraft.core24.publish`, which electron-builder does **not** read. Per `app-builder-lib` source (`SnapTarget.findSnapPublishConfig`), it resolves publish config from `config.snapcraft.publish` (or `config.snap`/`config.linux`/`config.publish`), never the nested `core24.publish`. With no config found it defaulted `channels` to `edge` (`snapStorePublisher.js`), which the `beta,stable`-scoped token rejects.

Fix: move the `publish` array up to `build.snapcraft.publish` (sibling of `base`/`core24`).

### `docs:` refresh CONTRIBUTING and README
Node 24 LTS, Electron 42.x (pinned), cloud.microsoft default URLs, corrected release process (`npm version`, `.github/release.yml`, snap-to-beta note, SNAPCRAFT_TOKEN rotation), core24/Flatpak 25.08 platform notes.

## Testing
- JSON validated.
- Real verification is the next release job publishing the snap to beta successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)