### PR TITLE
Notification fixes, settings migration, static AppImage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,13 +86,19 @@ prospect-mail/
 ├── .github/          # GitHub workflows, issue templates, and configuration
 ├── build/            # Build assets (icons, etc.)
 ├── misc/             # Miscellaneous files (screenshots, etc.)
+├── public/           # Scripts injected into the Outlook web app (unread observer, etc.)
+├── assets/           # Runtime icons (tray, notifications)
 ├── src/              # Source code
 │   ├── controller/   # Application controllers
+│   │   ├── about-preload.js
+│   │   ├── about-window.js
 │   │   ├── client-injector.js
 │   │   ├── mail-window-controller.js
 │   │   ├── preload.js
 │   │   └── tray-controller.js
-│   └── main.js       # Main application entry point
+│   ├── about.html    # About window markup
+│   ├── main.js       # Main application entry point
+│   └── settings.js   # Centralized settings store (defaults + migration)
 ├── package.json      # Project configuration and dependencies
 └── README.md         # Project documentation
 ```

--- a/README.md
+++ b/README.md
@@ -108,9 +108,8 @@ need to click in "Reload settings" to apply changes.
   "showWindowFrame": true,
   "hideOnClose": true,
   "hideOnMinimize": true,
-  "startMinimized": false,
-  "startMaximized": false,
-  "disableUnreadNotifications": false,
+  "startupWindowState": "normal",
+  "showUnreadNotifications": true,
   "customBrowserPath": "microsoft-edge"
 }
 ```
@@ -126,10 +125,15 @@ need to click in "Reload settings" to apply changes.
 | `showWindowFrame`   | Show/hide window frame and title bar                                                         | `true`                            |
 | `hideOnClose`       | Minimize to tray instead of quitting when closing window                                     | `true`                            |
 | `hideOnMinimize`    | Hide to tray when minimizing window                                                          | `true`                            |
-| `startMinimized`    | Start app minimized to tray (also available via tray menu or `--minimized` flag)             | `false`                           |
-| `startMaximized`    | Start app with the window maximized (also available via tray menu; ignored if `startMinimized` is `true`) | `false`             |
-| `disableUnreadNotifications` | Disable the "new messages" desktop notification while keeping calendar reminders enabled (also available via tray menu) | `false`                  |
+| `startupWindowState`| Window state on startup: `"normal"`, `"minimized"`, or `"maximized"` (also available via tray menu; `--minimized` flag forces minimized) | `"normal"`     |
+| `showUnreadNotifications` | Show the "new messages" desktop notification (calendar reminders are unaffected; also available via tray menu) | `true`                  |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |
+
+> [!NOTE]
+> Settings from before 1.3.0 are migrated automatically on first launch:
+> `startMinimized`/`startMaximized` become `startupWindowState`, and
+> `disableUnreadNotifications` becomes `showUnreadNotifications` (inverted). No
+> manual action is needed.
 
 > [!NOTE]
 > `outlook.cloud.microsoft` is Microsoft's unified-domain Outlook host and is

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ need to click in "Reload settings" to apply changes.
   ],
   "showWindowFrame": true,
   "hideOnClose": true,
-  "hideOnMinimize": true,
+  "hideOnMinimize": false,
   "startupWindowState": "normal",
   "showUnreadNotifications": true,
   "customBrowserPath": "microsoft-edge"
@@ -124,7 +124,7 @@ need to click in "Reload settings" to apply changes.
 | `safelinksUrls`     | Array of URL patterns for Microsoft Safe Links that open in external browser                 | See example above                 |
 | `showWindowFrame`   | Show/hide window frame and title bar                                                         | `true`                            |
 | `hideOnClose`       | Minimize to tray instead of quitting when closing window                                     | `true`                            |
-| `hideOnMinimize`    | Hide to tray when minimizing window                                                          | `true`                            |
+| `hideOnMinimize`    | Hide to tray when minimizing (off by default: minimize stays in the taskbar; restore via tray → Show if enabled) | `false`     |
 | `startupWindowState`| Window state on startup: `"normal"`, `"minimized"`, or `"maximized"` (also available via tray menu; `--minimized` flag forces minimized) | `"normal"`     |
 | `showUnreadNotifications` | Show the "new messages" desktop notification (calendar reminders are unaffected; also available via tray menu) | `true`                  |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ need to click in "Reload settings" to apply changes.
   "hideOnMinimize": false,
   "startupWindowState": "normal",
   "showUnreadNotifications": true,
+  "unreadNotificationSource": "inbox",
   "customBrowserPath": "microsoft-edge"
 }
 ```
@@ -127,6 +128,7 @@ need to click in "Reload settings" to apply changes.
 | `hideOnMinimize`    | Hide to tray when minimizing (off by default: minimize stays in the taskbar; restore via tray → Show if enabled) | `false`     |
 | `startupWindowState`| Window state on startup: `"normal"`, `"minimized"`, or `"maximized"` (also available via tray menu; `--minimized` flag forces minimized) | `"normal"`     |
 | `showUnreadNotifications` | Show the "new messages" desktop notification (calendar reminders are unaffected; also available via tray menu) | `true`                  |
+| `unreadNotificationSource` | Which folders drive the unread badge and new-mail notifications: `"inbox"` (Inbox only) or `"favorites"` (sum of unread across your Outlook Favorites) | `"inbox"`     |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ need to click in "Reload settings" to apply changes.
   "hideOnClose": true,
   "hideOnMinimize": true,
   "startMinimized": false,
+  "startMaximized": false,
   "disableUnreadNotifications": false,
   "customBrowserPath": "microsoft-edge"
 }
@@ -126,6 +127,7 @@ need to click in "Reload settings" to apply changes.
 | `hideOnClose`       | Minimize to tray instead of quitting when closing window                                     | `true`                            |
 | `hideOnMinimize`    | Hide to tray when minimizing window                                                          | `true`                            |
 | `startMinimized`    | Start app minimized to tray (also available via tray menu or `--minimized` flag)             | `false`                           |
+| `startMaximized`    | Start app with the window maximized (also available via tray menu; ignored if `startMinimized` is `true`) | `false`             |
 | `disableUnreadNotifications` | Disable the "new messages" desktop notification while keeping calendar reminders enabled (also available via tray menu) | `false`                  |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
   },
   "build": {
     "appId": "io.github.julian-alarcon.prospect-mail",
+    "toolsets": {
+      "appimage": "1.0.3"
+    },
     "linux": {
       "category": "Email;Network;Office",
       "packageCategory": "net",

--- a/public/unread-number-observer.js
+++ b/public/unread-number-observer.js
@@ -160,8 +160,8 @@ const observeUnreadHandlers = {
           });
 
           if (!lastUnreadNotificationTime || timeSinceLastNotification > CONFIG.unreadEmailThrottleMs) {
-            if (window.prospectMailConfig && window.prospectMailConfig.disableUnreadNotifications) {
-              console.log('Unread notification suppressed by user setting (disableUnreadNotifications)');
+            if (window.prospectMailConfig && window.prospectMailConfig.showUnreadNotifications === false) {
+              console.log('Unread notification suppressed by user setting (showUnreadNotifications=false)');
             } else {
               showNotification(
                 "Prospect Mail: New Messages",

--- a/public/unread-number-observer.js
+++ b/public/unread-number-observer.js
@@ -121,9 +121,15 @@ const observeUnreadHandlers = {
         return false;
       }
 
-      // Extract unread count from title attribute: "Inbox - 263 items (217 unread)"
+      // Extract unread count from title attribute. Outlook localizes the word
+      // ("unread"/"ungelesen"/"non lus"/...), but the count is always the first
+      // number inside the parentheses, so match the digits after the opening
+      // paren instead of the English word:
+      //   "Inbox - 263 items (217 unread)" / "Posteingang - 263 Elemente (217 ungelesen)"
+      // A folder with no unread messages omits the parenthetical, so no match
+      // correctly yields 0.
       const title = inboxElement.getAttribute('title');
-      const unreadMatch = title?.match(/\((\d+)\s+unread\)/);
+      const unreadMatch = title?.match(/\((\d+)/);
       const unread = unreadMatch ? parseInt(unreadMatch[1], 10) : 0;
 
       console.log(`Found ${unread} unread message(s)`);

--- a/public/unread-number-observer.js
+++ b/public/unread-number-observer.js
@@ -200,12 +200,17 @@ const observeUnreadHandlers = {
       subtree: true,
     });
 
-    // Timer to catch zero unread changes that observer might miss
+    // Periodic safety net for changes the mutation observer might miss.
+    // Runs a full check (checkOnlyZeroUnread=false) so it can also notify on a
+    // real increase. Passing true here silently advanced lastUnreadCount without
+    // notifying, so when the poll fired before the observer's debounced check a
+    // newly-arrived mail was swallowed (see #415). The unread>lastUnreadCount
+    // guard plus the anti-spam throttle still prevent duplicate notifications.
     if (unreadCheckTimer) {
       clearInterval(unreadCheckTimer);
     }
     unreadCheckTimer = setInterval(() => {
-      checkUnread(true);
+      checkUnread(false);
     }, CONFIG.unreadCheckIntervalMs);
 
     // Initial check

--- a/public/unread-number-observer.js
+++ b/public/unread-number-observer.js
@@ -115,22 +115,51 @@ const observeUnreadHandlers = {
       return false;
     }
 
+    // Parse the unread count from a folder's title tooltip. Outlook localizes
+    // the word ("unread"/"ungelesen"/"non lus"/...), but the count is always the
+    // first number inside the parentheses, so match the digits after the opening
+    // paren instead of the English word:
+    //   "Inbox - 263 items (217 unread)" / "Posteingang - 263 Elemente (217 ungelesen)"
+    // A folder with no unread messages omits the parenthetical (e.g.
+    // "Action - 0 items"), so no match correctly yields 0.
+    const parseUnread = (title) => {
+      const match = title?.match(/\((\d+)/);
+      return match ? parseInt(match[1], 10) : 0;
+    };
+
+    // Resolve how many unread messages to report, per the user's setting:
+    //   "inbox"     — the Inbox folder only (default, original behaviour)
+    //   "favorites" — sum of unread across the pinned Favorites folders (#343)
+    // Favorites live in one group anchored by the language-neutral internal id
+    // "favoritesRoot"; each favourite folder is a treeitem below the level-1
+    // "Favorites" header. Non-folder favourites (people, groups) have no
+    // "(N unread)" tooltip and parse to 0, so they don't affect the sum.
+    const getUnreadCount = () => {
+      const source =
+        (window.prospectMailConfig && window.prospectMailConfig.unreadNotificationSource) ||
+        "inbox";
+
+      if (source === "favorites") {
+        const favorites = document.querySelectorAll(
+          '[aria-labelledby="favoritesRoot"] [role="treeitem"]:not([aria-level="1"])'
+        );
+        let total = 0;
+        favorites.forEach((el) => {
+          total += parseUnread(el.getAttribute("title"));
+        });
+        return total;
+      }
+
+      return parseUnread(inboxElement.getAttribute("title"));
+    };
+
     const checkUnread = (checkOnlyZeroUnread) => {
       if (!inboxElement) {
         console.log("Invalid inbox element");
         return false;
       }
 
-      // Extract unread count from title attribute. Outlook localizes the word
-      // ("unread"/"ungelesen"/"non lus"/...), but the count is always the first
-      // number inside the parentheses, so match the digits after the opening
-      // paren instead of the English word:
-      //   "Inbox - 263 items (217 unread)" / "Posteingang - 263 Elemente (217 ungelesen)"
-      // A folder with no unread messages omits the parenthetical, so no match
-      // correctly yields 0.
-      const title = inboxElement.getAttribute('title');
-      const unreadMatch = title?.match(/\((\d+)/);
-      const unread = unreadMatch ? parseInt(unreadMatch[1], 10) : 0;
+      const unread = getUnreadCount();
 
       console.log(`Found ${unread} unread message(s)`);
 

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -65,7 +65,7 @@ class MailWindowController {
     this.init();
     // Check both command-line flag and settings for initial minimization
     const hasMinimizedFlag = global.cmdLine.indexOf("--minimized") !== -1;
-    const startMinimizedSetting = settings.get("startMinimized");
+    const startMinimizedSetting = settings.get("startupWindowState") === "minimized";
     initialMinimization.domReady = hasMinimizedFlag || startMinimizedSetting;
   }
   reloadSettings() {
@@ -383,9 +383,9 @@ class MailWindowController {
 
       this.addUnreadNumberObserver();
       if (!initialMinimization.domReady) {
-        // startMinimized takes precedence: if we're here the window isn't being
-        // minimized, so honor startMaximized. maximize() also shows the window.
-        if (settings.get("startMaximized")) {
+        // A minimized startup keeps the window hidden, so if we're here we only
+        // need to honor the maximized case. maximize() also shows the window.
+        if (settings.get("startupWindowState") === "maximized") {
           this.win.maximize();
         } else {
           this.win.show();
@@ -467,9 +467,9 @@ class MailWindowController {
   }
 
   addUnreadNumberObserver() {
-    const disableUnreadNotifications = settings.get("disableUnreadNotifications");
+    const showUnreadNotifications = settings.get("showUnreadNotifications");
     this.win.webContents.executeJavaScript(
-      `window.prospectMailConfig = Object.assign(window.prospectMailConfig || {}, { disableUnreadNotifications: ${JSON.stringify(disableUnreadNotifications)} });`
+      `window.prospectMailConfig = Object.assign(window.prospectMailConfig || {}, { showUnreadNotifications: ${JSON.stringify(showUnreadNotifications)} });`
     );
     this.win.webContents.executeJavaScript(
       getClientFile("unread-number-observer.js")

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -149,6 +149,11 @@ class MailWindowController {
       webPreferences: {
         contextIsolation: true,
         preload: path.join(__dirname, "preload.js"),
+        // Keep the injected unread observer's timers running while the window is
+        // hidden to tray (hideOnClose/hideOnMinimize). Chromium throttles timers
+        // in hidden windows by default, which stopped new-mail detection in the
+        // tray (#415).
+        backgroundThrottling: false,
       },
     });
 

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -473,8 +473,9 @@ class MailWindowController {
 
   addUnreadNumberObserver() {
     const showUnreadNotifications = settings.get("showUnreadNotifications");
+    const unreadNotificationSource = settings.get("unreadNotificationSource");
     this.win.webContents.executeJavaScript(
-      `window.prospectMailConfig = Object.assign(window.prospectMailConfig || {}, { showUnreadNotifications: ${JSON.stringify(showUnreadNotifications)} });`
+      `window.prospectMailConfig = Object.assign(window.prospectMailConfig || {}, { showUnreadNotifications: ${JSON.stringify(showUnreadNotifications)}, unreadNotificationSource: ${JSON.stringify(unreadNotificationSource)} });`
     );
     this.win.webContents.executeJavaScript(
       getClientFile("unread-number-observer.js")

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -383,7 +383,13 @@ class MailWindowController {
 
       this.addUnreadNumberObserver();
       if (!initialMinimization.domReady) {
-        this.win.show();
+        // startMinimized takes precedence: if we're here the window isn't being
+        // minimized, so honor startMaximized. maximize() also shows the window.
+        if (settings.get("startMaximized")) {
+          this.win.maximize();
+        } else {
+          this.win.show();
+        }
       }
     });
 

--- a/src/controller/tray-controller.js
+++ b/src/controller/tray-controller.js
@@ -51,17 +51,30 @@ class TrayController {
       {
         label: "Settings",
         submenu: [
+          // Startup state is a single choice, so use a radio group: normal,
+          // minimized, or maximized. This makes the mutual exclusivity explicit
+          // (you can't be both minimized and maximized). startMinimized wins
+          // when both flags are somehow set, so the "Maximized" radio is only
+          // active when not also minimized.
+          {
+            label: "Start Normal",
+            type: "radio",
+            checked:
+              !settings.get("startMinimized") && !settings.get("startMaximized"),
+            click: () => this.setStartupState("normal"),
+          },
           {
             label: "Start Minimized",
-            type: "checkbox",
+            type: "radio",
             checked: settings.get("startMinimized"),
-            click: () => this.toggleStartMinimized(),
+            click: () => this.setStartupState("minimized"),
           },
           {
             label: "Start Maximized",
-            type: "checkbox",
-            checked: settings.get("startMaximized"),
-            click: () => this.toggleStartMaximized(),
+            type: "radio",
+            checked:
+              settings.get("startMaximized") && !settings.get("startMinimized"),
+            click: () => this.setStartupState("maximized"),
           },
           { type: "separator" },
           {
@@ -84,22 +97,25 @@ class TrayController {
           },
           { type: "separator" },
           {
-            label: "Disable Unread Message Notifications",
+            // Positive phrasing: checked = notifications on. The underlying
+            // setting stays "disableUnreadNotifications" (negated here).
+            label: "Unread Message Notifications",
             type: "checkbox",
-            checked: settings.get("disableUnreadNotifications"),
+            checked: !settings.get("disableUnreadNotifications"),
             click: () => this.toggleDisableUnreadNotifications(),
           },
           { type: "separator" },
           {
-            label: "Show settings file",
+            label: "Show Settings File",
             click: () => shell.showItemInFolder(path.resolve(settings.path)),
           },
           {
-            label: "Restore Default Settings", // previously "Reset configuration"
+            // Trailing ellipsis (HIG convention): opens a confirmation dialog.
+            label: "Restore Default Settings…", // previously "Reset configuration"
             click: () => this.restoreDefaultSettings(),
           },
           {
-            label: "Reset Application Data", // previously "Fully reset"
+            label: "Reset Application Data…", // previously "Fully reset"
             click: () => this.confirmFullReset(),
           },
         ],
@@ -157,15 +173,12 @@ class TrayController {
     this.mailController.reloadWindow();
   }
 
-  toggleStartMinimized() {
-    let orivalue = settings.get("startMinimized");
-    settings.set("startMinimized", !orivalue);
-    this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
-  }
-  toggleStartMaximized() {
-    let orivalue = settings.get("startMaximized");
-    settings.set("startMaximized", !orivalue);
-    this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
+  setStartupState(state) {
+    // "normal" | "minimized" | "maximized" — mutually exclusive, so set both
+    // flags from the single choice.
+    settings.set("startMinimized", state === "minimized");
+    settings.set("startMaximized", state === "maximized");
+    this.buildContextMenu(); // Rebuild menu to reflect new radio state
   }
   toggleWindowFrame() {
     let orivalue = settings.get("showWindowFrame");

--- a/src/controller/tray-controller.js
+++ b/src/controller/tray-controller.js
@@ -57,6 +57,12 @@ class TrayController {
             checked: settings.get("startMinimized"),
             click: () => this.toggleStartMinimized(),
           },
+          {
+            label: "Start Maximized",
+            type: "checkbox",
+            checked: settings.get("startMaximized"),
+            click: () => this.toggleStartMaximized(),
+          },
           { type: "separator" },
           {
             label: "Hide on Close",
@@ -154,6 +160,11 @@ class TrayController {
   toggleStartMinimized() {
     let orivalue = settings.get("startMinimized");
     settings.set("startMinimized", !orivalue);
+    this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
+  }
+  toggleStartMaximized() {
+    let orivalue = settings.get("startMaximized");
+    settings.set("startMaximized", !orivalue);
     this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
   }
   toggleWindowFrame() {

--- a/src/controller/tray-controller.js
+++ b/src/controller/tray-controller.js
@@ -53,27 +53,23 @@ class TrayController {
         submenu: [
           // Startup state is a single choice, so use a radio group: normal,
           // minimized, or maximized. This makes the mutual exclusivity explicit
-          // (you can't be both minimized and maximized). startMinimized wins
-          // when both flags are somehow set, so the "Maximized" radio is only
-          // active when not also minimized.
+          // (you can't be both minimized and maximized).
           {
             label: "Start Normal",
             type: "radio",
-            checked:
-              !settings.get("startMinimized") && !settings.get("startMaximized"),
+            checked: settings.get("startupWindowState") === "normal",
             click: () => this.setStartupState("normal"),
           },
           {
             label: "Start Minimized",
             type: "radio",
-            checked: settings.get("startMinimized"),
+            checked: settings.get("startupWindowState") === "minimized",
             click: () => this.setStartupState("minimized"),
           },
           {
             label: "Start Maximized",
             type: "radio",
-            checked:
-              settings.get("startMaximized") && !settings.get("startMinimized"),
+            checked: settings.get("startupWindowState") === "maximized",
             click: () => this.setStartupState("maximized"),
           },
           { type: "separator" },
@@ -97,12 +93,11 @@ class TrayController {
           },
           { type: "separator" },
           {
-            // Positive phrasing: checked = notifications on. The underlying
-            // setting stays "disableUnreadNotifications" (negated here).
+            // Positive phrasing: checked = notifications on.
             label: "Unread Message Notifications",
             type: "checkbox",
-            checked: !settings.get("disableUnreadNotifications"),
-            click: () => this.toggleDisableUnreadNotifications(),
+            checked: settings.get("showUnreadNotifications"),
+            click: () => this.toggleUnreadNotifications(),
           },
           { type: "separator" },
           {
@@ -174,10 +169,8 @@ class TrayController {
   }
 
   setStartupState(state) {
-    // "normal" | "minimized" | "maximized" — mutually exclusive, so set both
-    // flags from the single choice.
-    settings.set("startMinimized", state === "minimized");
-    settings.set("startMaximized", state === "maximized");
+    // "normal" | "minimized" | "maximized"
+    settings.set("startupWindowState", state);
     this.buildContextMenu(); // Rebuild menu to reflect new radio state
   }
   toggleWindowFrame() {
@@ -198,9 +191,9 @@ class TrayController {
     settings.set("hideOnMinimize", !orivalue);
     this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
   }
-  toggleDisableUnreadNotifications() {
-    let orivalue = settings.get("disableUnreadNotifications");
-    settings.set("disableUnreadNotifications", !orivalue);
+  toggleUnreadNotifications() {
+    let orivalue = settings.get("showUnreadNotifications");
+    settings.set("showUnreadNotifications", !orivalue);
     this.buildContextMenu(); // Rebuild menu to reflect new checkbox state
     // Reload the window so the observer picks up the new setting
     this.mailController.reloadWindow();

--- a/src/settings.js
+++ b/src/settings.js
@@ -34,7 +34,10 @@ const settings = new Store({
     ],
     showWindowFrame: true,
     hideOnClose: true,
-    hideOnMinimize: true,
+    // Default off so minimize behaves like a standard window (stays in the
+    // taskbar), mirroring Teams for Linux. hideOnClose still sends the app to
+    // the tray, which is the more useful "keep running in background" case.
+    hideOnMinimize: false,
     // Startup window state is a single choice: "normal" | "minimized" | "maximized".
     startupWindowState: "normal",
     // Positive phrasing: true = show desktop notifications for new mail.

--- a/src/settings.js
+++ b/src/settings.js
@@ -42,6 +42,10 @@ const settings = new Store({
     startupWindowState: "normal",
     // Positive phrasing: true = show desktop notifications for new mail.
     showUnreadNotifications: true,
+    // Which folders drive the unread badge and new-mail notifications:
+    //   "inbox"     — the Inbox folder only (default, original behaviour)
+    //   "favorites" — sum of unread across the Outlook Favorites folders
+    unreadNotificationSource: "inbox",
     customBrowserPath: undefined
   }
 });

--- a/src/settings.js
+++ b/src/settings.js
@@ -36,6 +36,7 @@ const settings = new Store({
     hideOnClose: true,
     hideOnMinimize: true,
     startMinimized: false,
+    startMaximized: false,
     disableUnreadNotifications: false,
     customBrowserPath: undefined
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -35,11 +35,43 @@ const settings = new Store({
     showWindowFrame: true,
     hideOnClose: true,
     hideOnMinimize: true,
-    startMinimized: false,
-    startMaximized: false,
-    disableUnreadNotifications: false,
+    // Startup window state is a single choice: "normal" | "minimized" | "maximized".
+    startupWindowState: "normal",
+    // Positive phrasing: true = show desktop notifications for new mail.
+    showUnreadNotifications: true,
     customBrowserPath: undefined
   }
 });
+
+// One-time migration from the pre-1.3.0 settings schema to the current one.
+// Done imperatively (guarded by has()) rather than with electron-store's
+// version-keyed migrations, which behave unreliably across prerelease (-beta)
+// version strings. Legacy keys are no longer in `defaults`, so has() is true
+// only for values a previous version actually persisted to disk.
+migrateLegacySettings(settings);
+
+function migrateLegacySettings(store) {
+  // startMinimized + startMaximized booleans -> startupWindowState enum.
+  // startMinimized wins if both were somehow set.
+  if (store.has("startMinimized") || store.has("startMaximized")) {
+    const wasMinimized = store.get("startMinimized", false);
+    const wasMaximized = store.get("startMaximized", false);
+    store.set(
+      "startupWindowState",
+      wasMinimized ? "minimized" : wasMaximized ? "maximized" : "normal"
+    );
+    store.delete("startMinimized");
+    store.delete("startMaximized");
+  }
+
+  // disableUnreadNotifications (negated) -> showUnreadNotifications (positive).
+  if (store.has("disableUnreadNotifications")) {
+    store.set(
+      "showUnreadNotifications",
+      !store.get("disableUnreadNotifications")
+    );
+    store.delete("disableUnreadNotifications");
+  }
+}
 
 module.exports = settings;


### PR DESCRIPTION
## Summary

Polish pass ahead of the 1.3.0 release: notification reliability fixes, a settings-schema cleanup with automatic migration, a couple of new options, and a leaner AppImage. No breaking changes for users; legacy settings migrate on first launch.

## 🚀 Features

- **Notification source setting** (`unreadNotificationSource`): choose whether the unread badge and new-mail notifications track the Inbox only (`"inbox"`, default) or the sum across your Outlook **Favorites** (`"favorites"`). Closes #343.
- **Startup window state** (`startupWindowState`: `normal` / `minimized` / `maximized`), including opening maximized. Also selectable from the tray Settings menu. Closes #416.

## 🐛 Bug Fixes

- **Unread count now locale-independent**: parse the number in the folder tooltip instead of the English word "unread", so notifications fire on non-English Outlook UIs. Closes #426.
- **No more lost notifications from the poll/observer race**: the 5s poll now runs a full check instead of silently advancing the counter, so a new mail arriving just before the observer's debounced check is no longer swallowed. Part of #415.
- **Notifications keep working while hidden to tray**: `backgroundThrottling: false` stops Chromium from throttling the unread observer's timers when the window is hidden (`hideOnClose` / `hideOnMinimize`). Part of #415.

## 🔧 Build & CI

- **AppImage no longer needs libfuse2**: build with electron-builder's static AppImage runtime (`toolsets.appimage`). Verified the runtime is statically linked with no `libfuse.so.2` dependency. Closes #422.

## 🧹 Refactor / UX

- **Positive/enum settings schema with auto-migration**: `disableUnreadNotifications` → `showUnreadNotifications` (inverted), and `startMinimized`/`startMaximized` → `startupWindowState`. Migrated automatically on first launch, no manual action needed.
- **`hideOnMinimize` now defaults to off**: minimize stays in the taskbar (standard behaviour, mirrors Teams for Linux); `hideOnClose` still sends the app to the tray. Related to #387.
- Tray Settings menu tidy-up: radio group for startup state, positive notification label, casing and dialog-ellipsis fixes.

## 📚 Documentation

- README: documented the new/renamed settings and the migration note.
- CONTRIBUTING: refreshed the project-structure tree to match the current source layout.

## Testing

- `npm start`, verified: locale-independent unread parsing, notifications while closed to tray (observer keeps polling), and the Favorites notification source.
- Built an x64 AppImage and confirmed no libfuse2 dependency.

Closes #343, #416, #422, #426. Addresses #415 and #387.
