### PR TITLE
fix: detect Outlook session expiry via OWA AuthNeeded signal (closes #428)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,3 +33,7 @@ If applicable, add screenshots to help explain your problem.
 **Additional context**
 Add any other context about the problem here.
 Also, did you try another build (AppImage, deb, rpm)?
+And, did you tried checking the Developer Tools messages? Use
+Ctrl + Shift + I shortcut to show the Developer tools
+`export NODE_ENV="development" && prospect-mail` to open Prospect-Mail
+with the developer tools panel and check the logs in the console tab.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,7 +18,27 @@ env:
   SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 
 jobs:
+  # Fast gate: unit tests must pass before any build/release job runs.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+
+      - name: Install Node.js and NPM
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   build-and-release:
+    needs: test
     runs-on: ${{ matrix.runner }}
 
     # Platforms to build on/for
@@ -105,6 +125,7 @@ jobs:
         run: npm run dist:windows:${{ matrix.arch }} -- --publish always
 
   build-and-release-snap-arm64:
+    needs: test
     runs-on: ubuntu-26.04-arm
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+# Cancel superseded runs on the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+
+      - name: Install Node.js and NPM
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,6 +330,8 @@ When reporting bugs, please use the [bug report template](.github/ISSUE_TEMPLATE
   - Installation source (deb, rpm, snap, AppImage, tar.gz, Snapstore, exe, msi, dmg)
   - Version (e.g., 0.6.0-beta2)
 - Any additional context
+- Use shortcut Ctrl + Shift + I, or open with command
+  `export NODE_ENV="development" && prospect-mail` to view Developer Tools.
 
 Check if the issue occurs with different build types (AppImage, deb, rpm, etc.).
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "start": "electron .",
     "start-minimized": "electron . --minimized",
+    "test": "node --test",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "dist:linux": "electron-builder --linux",

--- a/public/unread-number-observer.js
+++ b/public/unread-number-observer.js
@@ -12,10 +12,10 @@ const CONFIG = {
   handlerRetryDelayMs: 5000,         // 5 seconds before retrying failed handlers
   handlerRetryAgainDelayMs: 10000,   // 10 seconds for subsequent retry attempts
 
-  // Login-required detection
-  loginRequiredInitialGraceMs: 30000, // don't detect login-required in the first 30s (avoids false positives during initial auth redirects)
-  loginRequiredThresholdMs: 60000,   // 60s with no inbox after grace = likely logged out
-  loginCheckIntervalMs: 30000,       // 30s between login-state checks
+  // Session-expiry / sign-in detection (see the detection block below)
+  authNeededWindowMs: 20000, // window over which repeated AuthNeeded errors are counted
+  authNeededMinHits: 2,      // AuthNeeded rejections within the window before we notify
+  loginPageConfirmMs: 8000,  // a sign-in URL must persist this long to count (ignores SSO bounces)
 };
 
 let unreadCheckTimer;
@@ -35,18 +35,19 @@ const showNotification = (title, body) => {
   console.log('Native notification request sent to main process');
 };
 
-// ── Login-required detection ──────────────────────────────────────────────
-// When the Outlook session expires the inbox DOM disappears (the page shows
-// a sign-in screen or a stale-session banner). The existing handler retries
-// cover slow loading, but if the inbox never appears we report it to the main
-// process, which can auto-reload to recover via SSO or notify the user.
+// ── Session-expiry / sign-in detection ─────────────────────────────────────
+// Outlook Web never surfaces MSAL's `interaction_required`. Instead its data
+// layer rejects failed calls with "<operation> failed: AuthNeeded" while the
+// session is expired (the red "Your session has expired" banner, with the mail
+// UI still fully rendered). That `AuthNeeded` token is our language-independent
+// signal. The other case is a hard redirect to a Microsoft sign-in page.
+//
+// Neither auto-reloads: silent SSO has already failed, so only an interactive
+// sign-in recovers, and a blind reload would loop or wipe a half-entered login.
+// We just notify the main process, which can warn a tray/minimized user. A
+// stuck/blank page from a dropped connection is handled separately, in the main
+// process, via `did-fail-load` (a real network error, not a login problem).
 let loginRequiredReported = false;
-// Timestamp of when the Outlook mail UI was last confirmed present. While the
-// UI is visible we keep pushing this forward, so only a *sustained* absence
-// (the session really expired) accumulates toward the threshold. A brief moment
-// where the inbox node isn't in the DOM can no longer trigger a reload (#428).
-let lastLoggedInAt = Date.now();
-let loginCheckInterval = null;
 
 const LOGIN_URL_PATTERNS = [
   'login.microsoftonline.com',
@@ -54,78 +55,62 @@ const LOGIN_URL_PATTERNS = [
   'login.microsoft.com',
 ];
 
+const isOnLoginPageUrl = (href) =>
+  !!href && LOGIN_URL_PATTERNS.some((p) => href.includes(p));
+
 const isOnLoginPage = () => {
   try {
-    const href = window.location.href;
-    return LOGIN_URL_PATTERNS.some(p => href.includes(p));
+    return isOnLoginPageUrl(window.location.href);
   } catch {
     return false;
   }
 };
 
-// True when the Outlook web app shell is rendered, i.e. we're signed in. The
-// shell tags its major regions with `data-app-section` (NavigationPane,
-// MessageList, NotificationPane, ...) and the folder tree exposes the inbox
-// node; the Microsoft sign-in pages use neither. ANY of these counts as
-// "logged in" on purpose: a narrow single-selector check was the root cause of
-// the reload loop, so we deliberately err toward not reloading.
-const isLoggedIn = () => {
-  try {
-    return !!document.querySelector('[data-folder-name="inbox"], [data-app-section]');
-  } catch {
-    return false;
-  }
+// Pull a string message out of whatever a promise rejected with.
+const rejectionMessage = (reason) => {
+  if (!reason) return '';
+  if (typeof reason === 'string') return reason;
+  return reason.message || reason.errorMessage || String(reason);
 };
 
-const checkLoginRequired = () => {
+// OWA marks an expired session by rejecting data calls with a "...: AuthNeeded"
+// error. Match the whole token so an unrelated word can't false-match.
+const isAuthNeededRejection = (reason) => /\bAuthNeeded\b/.test(rejectionMessage(reason));
+
+const reportLoginRequired = (reason) => {
   if (loginRequiredReported) return;
+  loginRequiredReported = true;
+  console.log('Login required detected, reporting to main process', { reason });
+  window.electronAPI.reportLoginRequired(reason);
+};
 
-  // As long as the mail UI is present we're logged in: advance the clock and
-  // bail. This is what stops transient missing-DOM moments (view switches,
-  // virtualized panes, the window hidden to tray) from ever accumulating
-  // toward the logged-out threshold.
-  if (isLoggedIn()) {
-    lastLoggedInAt = Date.now();
-    return;
-  }
-
-  const elapsed = Date.now() - lastLoggedInAt;
-
-  // Grace period avoids false positives from transient auth redirects right
-  // after a (re)load, before the app shell has had a chance to render.
-  if (elapsed < CONFIG.loginRequiredInitialGraceMs) return;
-
-  // On a real Microsoft sign-in page the user must sign in manually; auto-
-  // reloading would wipe a half-entered form or break MFA, so we only notify.
-  if (isOnLoginPage()) {
-    console.log('Login required detected (sign-in page), notifying main process', {
-      elapsedMs: elapsed,
-    });
-    loginRequiredReported = true;
-    window.electronAPI.reportLoginRequired('login-page');
-    return;
-  }
-
-  // Not on a sign-in page and the mail UI has been absent past the threshold:
-  // the page is stuck/blank but SSO cookies may still be valid, so ask the main
-  // process to reload for a silent recovery.
-  if (elapsed > CONFIG.loginRequiredThresholdMs) {
-    console.log('Login required detected (no mail UI), reporting to main process', {
-      elapsedMs: elapsed,
-    });
-    loginRequiredReported = true;
-    window.electronAPI.reportLoginRequired('no-inbox');
-  }
+// Require a few AuthNeeded rejections within a short window before notifying: a
+// single one can occur transiently during a normal token refresh, but a
+// genuinely expired session keeps emitting them as OWA retries its data calls.
+let authNeededHits = [];
+const recordAuthNeeded = (now = Date.now()) => {
+  authNeededHits = authNeededHits.filter((t) => now - t < CONFIG.authNeededWindowMs);
+  authNeededHits.push(now);
+  return authNeededHits.length >= CONFIG.authNeededMinHits;
 };
 
 const startLoginCheck = () => {
-  if (loginCheckInterval) return;
-  // Immediate check catches an initial sign-in-page redirect without waiting.
-  checkLoginRequired();
-  // Keep checking for the whole session: checkLoginRequired() is a no-op while
-  // logged in and self-latches once it reports, so this stays cheap yet can
-  // still catch a session that expires later on.
-  loginCheckInterval = setInterval(checkLoginRequired, CONFIG.loginCheckIntervalMs);
+  // Genuine session expiry: OWA's data layer rejects with AuthNeeded.
+  window.addEventListener('unhandledrejection', (event) => {
+    if (isAuthNeededRejection(event.reason) && recordAuthNeeded()) {
+      reportLoginRequired('session-expired');
+    }
+  });
+
+  // Hard redirect to a Microsoft sign-in page. Confirm it persists so a brief
+  // SSO bounce during initial load doesn't fire a false notification: if the
+  // page navigates on to Outlook, this script's context is gone and the timer
+  // never runs.
+  if (isOnLoginPage()) {
+    setTimeout(() => {
+      if (isOnLoginPage()) reportLoginRequired('login-page');
+    }, CONFIG.loginPageConfirmMs);
+  }
 };
 
 const observeUnreadHandlers = {
@@ -402,9 +387,8 @@ const initializeEmailMonitoring = () => {
     setTimeout(initializeEmailMonitoring, CONFIG.handlerRetryDelayMs);
   }
 
-  // Start monitoring for a login-required state. This is independent of the
-  // handler retries above: if the inbox never appears (session expired), the
-  // main process is notified so it can auto-reload or warn the user.
+  // Start watching for a session-expiry / sign-in-required state, independent
+  // of the handler retries above, so a tray/minimized user gets notified.
   startLoginCheck();
 };
 
@@ -427,18 +411,17 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 } else if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     CONFIG,
-    isLoggedIn,
+    isOnLoginPageUrl,
     isOnLoginPage,
-    checkLoginRequired,
+    rejectionMessage,
+    isAuthNeededRejection,
+    recordAuthNeeded,
+    reportLoginRequired,
     startLoginCheck,
     // Test hook: reset the module's login-detection state between scenarios.
     _resetLoginStateForTest() {
       loginRequiredReported = false;
-      lastLoggedInAt = Date.now();
-      if (loginCheckInterval) {
-        clearInterval(loginCheckInterval);
-        loginCheckInterval = null;
-      }
+      authNeededHits = [];
     },
   };
 }

--- a/public/unread-number-observer.js
+++ b/public/unread-number-observer.js
@@ -41,7 +41,11 @@ const showNotification = (title, body) => {
 // cover slow loading, but if the inbox never appears we report it to the main
 // process, which can auto-reload to recover via SSO or notify the user.
 let loginRequiredReported = false;
-let monitoringStartTime = Date.now();
+// Timestamp of when the Outlook mail UI was last confirmed present. While the
+// UI is visible we keep pushing this forward, so only a *sustained* absence
+// (the session really expired) accumulates toward the threshold. A brief moment
+// where the inbox node isn't in the DOM can no longer trigger a reload (#428).
+let lastLoggedInAt = Date.now();
 let loginCheckInterval = null;
 
 const LOGIN_URL_PATTERNS = [
@@ -59,50 +63,69 @@ const isOnLoginPage = () => {
   }
 };
 
+// True when the Outlook web app shell is rendered, i.e. we're signed in. The
+// shell tags its major regions with `data-app-section` (NavigationPane,
+// MessageList, NotificationPane, ...) and the folder tree exposes the inbox
+// node; the Microsoft sign-in pages use neither. ANY of these counts as
+// "logged in" on purpose: a narrow single-selector check was the root cause of
+// the reload loop, so we deliberately err toward not reloading.
+const isLoggedIn = () => {
+  try {
+    return !!document.querySelector('[data-folder-name="inbox"], [data-app-section]');
+  } catch {
+    return false;
+  }
+};
+
 const checkLoginRequired = () => {
   if (loginRequiredReported) return;
-  const elapsed = Date.now() - monitoringStartTime;
 
-  // Skip detection during the initial grace period to avoid false positives
-  // from transient auth redirects when the page first loads.
-  if (elapsed < CONFIG.loginRequiredInitialGraceMs) {
+  // As long as the mail UI is present we're logged in: advance the clock and
+  // bail. This is what stops transient missing-DOM moments (view switches,
+  // virtualized panes, the window hidden to tray) from ever accumulating
+  // toward the logged-out threshold.
+  if (isLoggedIn()) {
+    lastLoggedInAt = Date.now();
     return;
   }
 
-  // Two distinct signals, reported with a reason so the main process can react
-  // differently:
-  //   'login-page' — we're sitting on a Microsoft sign-in page. The user must
-  //     sign in manually; auto-reloading would wipe a half-entered form or break
-  //     an MFA flow, so the main process only notifies for this case.
-  //   'no-inbox'   — the page loaded but no inbox appeared for over the
-  //     threshold (stuck/blank). SSO cookies may still be valid, so the main
-  //     process reloads to attempt silent recovery.
-  const onLoginPage = isOnLoginPage();
-  if (onLoginPage || elapsed > CONFIG.loginRequiredThresholdMs) {
-    const reason = onLoginPage ? 'login-page' : 'no-inbox';
-    console.log('Login required detected, reporting to main process', {
-      reason,
+  const elapsed = Date.now() - lastLoggedInAt;
+
+  // Grace period avoids false positives from transient auth redirects right
+  // after a (re)load, before the app shell has had a chance to render.
+  if (elapsed < CONFIG.loginRequiredInitialGraceMs) return;
+
+  // On a real Microsoft sign-in page the user must sign in manually; auto-
+  // reloading would wipe a half-entered form or break MFA, so we only notify.
+  if (isOnLoginPage()) {
+    console.log('Login required detected (sign-in page), notifying main process', {
       elapsedMs: elapsed,
     });
     loginRequiredReported = true;
-    window.electronAPI.reportLoginRequired(reason);
+    window.electronAPI.reportLoginRequired('login-page');
+    return;
+  }
+
+  // Not on a sign-in page and the mail UI has been absent past the threshold:
+  // the page is stuck/blank but SSO cookies may still be valid, so ask the main
+  // process to reload for a silent recovery.
+  if (elapsed > CONFIG.loginRequiredThresholdMs) {
+    console.log('Login required detected (no mail UI), reporting to main process', {
+      elapsedMs: elapsed,
+    });
+    loginRequiredReported = true;
+    window.electronAPI.reportLoginRequired('no-inbox');
   }
 };
 
 const startLoginCheck = () => {
   if (loginCheckInterval) return;
-  // Immediate check catches the definite login-page redirect without waiting.
+  // Immediate check catches an initial sign-in-page redirect without waiting.
   checkLoginRequired();
-  loginCheckInterval = setInterval(() => {
-    // If the inbox is present, we're logged in — stop checking.
-    if (document.querySelector('[data-folder-name="inbox"]')) {
-      console.log('Inbox found, user is logged in — stopping login check');
-      clearInterval(loginCheckInterval);
-      loginCheckInterval = null;
-      return;
-    }
-    checkLoginRequired();
-  }, CONFIG.loginCheckIntervalMs);
+  // Keep checking for the whole session: checkLoginRequired() is a no-op while
+  // logged in and self-latches once it reports, so this stays cheap yet can
+  // still catch a session that expires later on.
+  loginCheckInterval = setInterval(checkLoginRequired, CONFIG.loginCheckIntervalMs);
 };
 
 const observeUnreadHandlers = {
@@ -396,4 +419,26 @@ const debounce = (() => {
   };
 })();
 
-initializeEmailMonitoring();
+// Auto-start only in the page (where this script is injected via
+// executeJavaScript). In a Node test harness `window` is absent, so we skip the
+// browser bootstrap and instead expose the detection helpers for unit tests.
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  initializeEmailMonitoring();
+} else if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    CONFIG,
+    isLoggedIn,
+    isOnLoginPage,
+    checkLoginRequired,
+    startLoginCheck,
+    // Test hook: reset the module's login-detection state between scenarios.
+    _resetLoginStateForTest() {
+      loginRequiredReported = false;
+      lastLoggedInAt = Date.now();
+      if (loginCheckInterval) {
+        clearInterval(loginCheckInterval);
+        loginCheckInterval = null;
+      }
+    },
+  };
+}

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -40,18 +40,28 @@ const AUTH_COOKIE_NAMES = new Set([
   "rtFa",
 ]);
 
-// Login-required recovery state. Lives in the main process so it survives
-// page reloads (renderer state is wiped on each reload).
-let loginRequiredRetryCount = 0;
-let lastLoginRequiredReloadAt = 0;
-let loginRequiredResetTimer = null;
-const LOGIN_REQUIRED_COOLDOWN_MS = 60 * 1000; // 1 minute between reload attempts
-const MAX_LOGIN_REQUIRED_RETRIES = 3;          // then fall back to notification
-// Quiet window after a recovery reload with no further login-required report
-// before we treat recovery as successful and reset the retry counter. Resetting
-// on every navigation (the reload itself navigates to Outlook) let the loop run
-// forever, defeating the retry cap (#428).
-const LOGIN_REQUIRED_RESET_QUIET_MS = 2 * LOGIN_REQUIRED_COOLDOWN_MS;
+// Network-recovery state. Lives in the main process so it survives renderer
+// reloads. A dropped connection surfaces as a main-frame `did-fail-load`; we
+// reload once, debounced, so a burst of failures triggers a single reload.
+let lastNetworkReloadAt = 0;
+const NETWORK_RELOAD_MIN_INTERVAL_MS = 5 * 1000;
+// Chromium net error codes worth reloading for (transient connectivity). We
+// deliberately exclude ERR_ABORTED (-3, normal SPA navigation) and cert/HTTP
+// errors, which a reload won't fix.
+const RECOVERABLE_NET_ERRORS = new Set([
+  -2,   // ERR_FAILED
+  -21,  // ERR_NETWORK_CHANGED
+  -100, // ERR_CONNECTION_CLOSED
+  -101, // ERR_CONNECTION_RESET
+  -102, // ERR_CONNECTION_REFUSED
+  -104, // ERR_CONNECTION_FAILED
+  -105, // ERR_NAME_NOT_RESOLVED
+  -106, // ERR_INTERNET_DISCONNECTED
+  -109, // ERR_ADDRESS_UNREACHABLE
+  -118, // ERR_CONNECTION_TIMED_OUT
+  -130, // ERR_PROXY_CONNECTION_FAILED
+  -137, // ERR_NAME_RESOLUTION_FAILED
+]);
 
 //Setted by cmdLine to initial minimization
 const initialMinimization = {
@@ -316,62 +326,38 @@ class MailWindowController {
       notification.show();
     });
 
-    // Login-required recovery: the renderer reports that the inbox can't be
-    // found (session expired / redirected to sign-in). We attempt a silent
-    // reload a few times — if Outlook's SSO cookies are still valid the reload
-    // re-authenticates transparently. After max retries we notify the user.
+    // Session-expiry / sign-in required: the renderer detects that Outlook needs
+    // an interactive sign-in (an expired session — the red banner — or a
+    // Microsoft sign-in page). Silent SSO has already failed at this point, so a
+    // reload can't recover it and would only loop or wipe a half-entered login.
+    // We just notify, so a tray/minimized user knows to open the window and sign
+    // in (the in-page banner has its own Sign in button). A stuck/blank page
+    // from a dropped connection is a different problem, handled by did-fail-load.
     ipcMain.on("report-login-required", (_event, reason) => {
-      const now = Date.now();
-
-      // On a real sign-in page: reloading can't recover the session (silent SSO
-      // already failed) and would interrupt the user typing credentials or doing
-      // MFA. Just notify so a minimized/tray user knows to sign in.
-      if (reason === "login-page") {
-        console.log("[LoginRequired] On sign-in page, notifying (no reload)");
-        this.showAppNotification(
-          "Prospect Mail: Sign in required",
-          "Outlook requires you to sign in again. Click here to open Prospect Mail."
-        );
-        return;
-      }
-
-      if (loginRequiredRetryCount >= MAX_LOGIN_REQUIRED_RETRIES) {
-        console.log("[LoginRequired] Max retries reached, showing notification");
-        this.showAppNotification(
-          "Prospect Mail: Sign in required",
-          "Outlook requires you to sign in again. Click here to open Prospect Mail."
-        );
-        return;
-      }
-
-      if (lastLoginRequiredReloadAt > 0 && now - lastLoginRequiredReloadAt < LOGIN_REQUIRED_COOLDOWN_MS) {
-        console.log("[LoginRequired] Within cooldown, ignoring");
-        return;
-      }
-
-      loginRequiredRetryCount++;
-      lastLoginRequiredReloadAt = now;
-      console.log(
-        `[LoginRequired] Auto-reloading to recover session (attempt ${loginRequiredRetryCount}/${MAX_LOGIN_REQUIRED_RETRIES})`
+      console.log(`[LoginRequired] Sign-in required (${reason}), notifying`);
+      this.showAppNotification(
+        "Prospect Mail: Sign in required",
+        "Outlook requires you to sign in again. Click here to open Prospect Mail."
       );
-      this.reloadWindow();
-
-      // Consider recovery successful only if no further login-required report
-      // arrives for a sustained quiet period, then reset the counter so a
-      // genuine future logout gets a fresh set of retries. Each new report
-      // re-arms this, so a real persistent logout still stops after the cap
-      // instead of looping (#428).
-      if (loginRequiredResetTimer) {
-        clearTimeout(loginRequiredResetTimer);
-      }
-      loginRequiredResetTimer = setTimeout(() => {
-        if (loginRequiredRetryCount > 0) {
-          console.log("[LoginRequired] Recovery stable, resetting retry count");
-          loginRequiredRetryCount = 0;
-        }
-        loginRequiredResetTimer = null;
-      }, LOGIN_REQUIRED_RESET_QUIET_MS);
     });
+
+    // Network recovery: reload when the main frame fails to load with a
+    // transient connectivity error (e.g. after sleep or a network change).
+    // Debounced so a burst of failures triggers a single reload; sub-frame and
+    // non-recoverable errors (aborts, cert/HTTP) are ignored.
+    this.win.webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+        if (!isMainFrame || !RECOVERABLE_NET_ERRORS.has(errorCode)) return;
+        const now = Date.now();
+        if (now - lastNetworkReloadAt < NETWORK_RELOAD_MIN_INTERVAL_MS) return;
+        lastNetworkReloadAt = now;
+        console.log(
+          `[Network] Main frame failed to load (${errorCode} ${errorDescription}), reloading`
+        );
+        this.reloadWindow();
+      }
+    );
 
     // After resuming from sleep, cookies may have expired during suspend.
     // Clean them so Outlook doesn't show a stale session state.
@@ -531,8 +517,8 @@ class MailWindowController {
   }
 
   /**
-   * Shows a native notification directly from the main process (used for the
-   * login-required fallback when auto-reload is exhausted).
+   * Shows a native notification directly from the main process (used to tell a
+   * tray/minimized user that Outlook needs an interactive sign-in).
    */
   showAppNotification(title, body) {
     const { Notification } = require("electron");

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -44,16 +44,14 @@ const AUTH_COOKIE_NAMES = new Set([
 // page reloads (renderer state is wiped on each reload).
 let loginRequiredRetryCount = 0;
 let lastLoginRequiredReloadAt = 0;
+let loginRequiredResetTimer = null;
 const LOGIN_REQUIRED_COOLDOWN_MS = 60 * 1000; // 1 minute between reload attempts
 const MAX_LOGIN_REQUIRED_RETRIES = 3;          // then fall back to notification
-
-// Outlook mail URL patterns — landing here means recovery worked
-const OUTLOOK_URL_PATTERNS = [
-  "outlook.cloud.microsoft",
-  "outlook.office.com",
-  "outlook.live.com",
-  "outlook.office365.com",
-];
+// Quiet window after a recovery reload with no further login-required report
+// before we treat recovery as successful and reset the retry counter. Resetting
+// on every navigation (the reload itself navigates to Outlook) let the loop run
+// forever, defeating the retry cap (#428).
+const LOGIN_REQUIRED_RESET_QUIET_MS = 2 * LOGIN_REQUIRED_COOLDOWN_MS;
 
 //Setted by cmdLine to initial minimization
 const initialMinimization = {
@@ -357,19 +355,22 @@ class MailWindowController {
         `[LoginRequired] Auto-reloading to recover session (attempt ${loginRequiredRetryCount}/${MAX_LOGIN_REQUIRED_RETRIES})`
       );
       this.reloadWindow();
-    });
 
-    // Reset the retry counter when we land back on an Outlook mail page —
-    // that means a reload (or manual sign-in) succeeded.
-    this.win.webContents.on("did-navigate", (_event, url) => {
-      if (
-        url &&
-        OUTLOOK_URL_PATTERNS.some((p) => url.includes(p)) &&
-        loginRequiredRetryCount > 0
-      ) {
-        console.log("[LoginRequired] Back on Outlook, resetting retry count");
-        loginRequiredRetryCount = 0;
+      // Consider recovery successful only if no further login-required report
+      // arrives for a sustained quiet period, then reset the counter so a
+      // genuine future logout gets a fresh set of retries. Each new report
+      // re-arms this, so a real persistent logout still stops after the cap
+      // instead of looping (#428).
+      if (loginRequiredResetTimer) {
+        clearTimeout(loginRequiredResetTimer);
       }
+      loginRequiredResetTimer = setTimeout(() => {
+        if (loginRequiredRetryCount > 0) {
+          console.log("[LoginRequired] Recovery stable, resetting retry count");
+          loginRequiredRetryCount = 0;
+        }
+        loginRequiredResetTimer = null;
+      }, LOGIN_REQUIRED_RESET_QUIET_MS);
     });
 
     // After resuming from sleep, cookies may have expired during suspend.

--- a/test/login-detection.test.js
+++ b/test/login-detection.test.js
@@ -1,0 +1,184 @@
+// Unit tests for the session-expiry / sign-in detection in the injected
+// unread observer. Regression coverage for #428: normal Mail/Calendar/Contacts
+// use must never trigger a login-required report; only a genuinely expired
+// session (repeated AuthNeeded rejections) or a persistent sign-in page should.
+const test = require("node:test");
+const assert = require("node:assert");
+const path = require("node:path");
+
+const MODULE_PATH = path.join(
+  __dirname,
+  "..",
+  "public",
+  "unread-number-observer.js"
+);
+
+// The observer exports its helpers only when `window` is absent at load time
+// (the Node path). Require it once with no browser globals, then drive the
+// helpers with a mocked window per test.
+const observer = require(MODULE_PATH);
+
+// Build a minimal browser-like environment and install it on globalThis so the
+// module's free `window` references resolve to it at call time.
+function mockWindow({ href = "https://outlook.office.com/mail/" } = {}) {
+  const reported = [];
+  const listeners = {};
+  global.window = {
+    location: { href },
+    electronAPI: { reportLoginRequired: (r) => reported.push(r) },
+    addEventListener: (type, fn) => {
+      listeners[type] = fn;
+    },
+  };
+  global.document = {};
+  return {
+    reported,
+    listeners,
+    setHref: (h) => {
+      global.window.location.href = h;
+    },
+    fireRejection: (reason) => {
+      listeners.unhandledrejection?.({ reason });
+    },
+  };
+}
+
+test.afterEach(() => {
+  observer._resetLoginStateForTest();
+  delete global.window;
+  delete global.document;
+});
+
+test("isOnLoginPageUrl matches only Microsoft sign-in hosts", () => {
+  assert.strictEqual(
+    observer.isOnLoginPageUrl("https://login.microsoftonline.com/common/oauth2"),
+    true
+  );
+  assert.strictEqual(
+    observer.isOnLoginPageUrl("https://login.live.com/oauth20_authorize.srf"),
+    true
+  );
+  assert.strictEqual(
+    observer.isOnLoginPageUrl("https://login.microsoft.com/foo"),
+    true
+  );
+  assert.strictEqual(
+    observer.isOnLoginPageUrl("https://outlook.office.com/mail/"),
+    false
+  );
+  assert.strictEqual(
+    observer.isOnLoginPageUrl("https://outlook.cloud.microsoft/people/"),
+    false
+  );
+  assert.strictEqual(observer.isOnLoginPageUrl(""), false);
+  assert.strictEqual(observer.isOnLoginPageUrl(null), false);
+});
+
+test("rejectionMessage extracts a string from varied reason shapes", () => {
+  assert.strictEqual(observer.rejectionMessage("plain string"), "plain string");
+  assert.strictEqual(
+    observer.rejectionMessage(new Error("boom")),
+    "boom"
+  );
+  assert.strictEqual(
+    observer.rejectionMessage({ errorMessage: "custom field" }),
+    "custom field"
+  );
+  assert.strictEqual(observer.rejectionMessage(null), "");
+  assert.strictEqual(observer.rejectionMessage(undefined), "");
+});
+
+test("isAuthNeededRejection matches the AuthNeeded token exactly", () => {
+  assert.strictEqual(
+    observer.isAuthNeededRejection("GetFolderChangeDigest failed: AuthNeeded"),
+    true
+  );
+  assert.strictEqual(
+    observer.isAuthNeededRejection(new Error("StartSubscription failed: AuthNeeded")),
+    true
+  );
+  // Case-sensitive, whole-token: unrelated words must not match.
+  assert.strictEqual(observer.isAuthNeededRejection("authneeded"), false);
+  assert.strictEqual(observer.isAuthNeededRejection("AuthNeededExtra"), false);
+  assert.strictEqual(
+    observer.isAuthNeededRejection("ResizeObserver loop limit exceeded"),
+    false
+  );
+  assert.strictEqual(observer.isAuthNeededRejection(null), false);
+});
+
+test("recordAuthNeeded requires minHits within the window", () => {
+  const base = 1_000_000;
+  // First hit is below the threshold.
+  assert.strictEqual(observer.recordAuthNeeded(base), false);
+  // Second hit inside the window reaches minHits (2).
+  assert.strictEqual(observer.recordAuthNeeded(base + 1000), true);
+});
+
+test("recordAuthNeeded forgets hits older than the window", () => {
+  const base = 1_000_000;
+  assert.strictEqual(observer.recordAuthNeeded(base), false);
+  // A hit past the window drops the stale one, so this counts as the first.
+  const afterWindow = base + observer.CONFIG.authNeededWindowMs + 1;
+  assert.strictEqual(observer.recordAuthNeeded(afterWindow), false);
+});
+
+test("normal use (no AuthNeeded, not a login page) never reports", () => {
+  // Covers Mail, Calendar, and Contacts: there is no DOM heuristic anymore, so
+  // benign rejections on any view must stay silent (the #428 regression).
+  for (const href of [
+    "https://outlook.office.com/mail/",
+    "https://outlook.office.com/calendar/",
+    "https://outlook.cloud.microsoft/people/",
+  ]) {
+    const env = mockWindow({ href });
+    observer.startLoginCheck();
+    env.fireRejection("ResizeObserver loop limit exceeded");
+    env.fireRejection(new Error("Some unrelated network blip"));
+    assert.deepStrictEqual(env.reported, [], `should stay silent on ${href}`);
+    observer._resetLoginStateForTest();
+    delete global.window;
+    delete global.document;
+  }
+});
+
+test("a single AuthNeeded rejection does not report", () => {
+  const env = mockWindow();
+  observer.startLoginCheck();
+  env.fireRejection("GetFolderChangeDigest failed: AuthNeeded");
+  assert.deepStrictEqual(env.reported, []);
+});
+
+test("repeated AuthNeeded rejections report session-expired once", () => {
+  const env = mockWindow();
+  observer.startLoginCheck();
+  env.fireRejection("GetFolderChangeDigest failed: AuthNeeded");
+  env.fireRejection(new Error("StartSubscription failed: AuthNeeded"));
+  assert.deepStrictEqual(env.reported, ["session-expired"]);
+  // Further rejections must not re-notify.
+  env.fireRejection("GetConversationItems failed: AuthNeeded");
+  assert.deepStrictEqual(env.reported, ["session-expired"]);
+});
+
+test("a persistent sign-in page reports login-page", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const env = mockWindow({
+    href: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  });
+  observer.startLoginCheck();
+  assert.deepStrictEqual(env.reported, []); // not until it persists
+  t.mock.timers.tick(observer.CONFIG.loginPageConfirmMs);
+  assert.deepStrictEqual(env.reported, ["login-page"]);
+});
+
+test("a transient sign-in bounce does not report login-page", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const env = mockWindow({
+    href: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  });
+  observer.startLoginCheck();
+  // SSO bounces back to Outlook before the confirm delay elapses.
+  env.setHref("https://outlook.office.com/mail/");
+  t.mock.timers.tick(observer.CONFIG.loginPageConfirmMs);
+  assert.deepStrictEqual(env.reported, []);
+});


### PR DESCRIPTION
## Summary

Fixes the reload loop in #428 where the window reloaded every ~60-90s for logged-in users on 1.3.0 (introduced by the login-required auto-recovery in #419), and replaces the fragile detection with a signal Outlook actually emits.

## Root cause

The renderer reported `no-inbox` based on **elapsed time alone**, never re-confirming the inbox was gone. When the inbox node briefly left the DOM (view switch, virtualized folder pane, hidden to tray, locale/DOM variance) the check fired, the main process reloaded, `did-navigate` reset the retry counter, and the cycle repeated forever. That is why the retry cap never stopped it and why downgrading to 1.2.1 fixed it.

## Approach

An earlier commit on this branch tried to harden the DOM heuristic (confirm the mail UI is absent before reloading). That was still a guess. Investigation with live diagnostics showed Outlook Web never surfaces MSAL `interaction_required`; its expired-session signal is a renderer unhandled rejection whose message contains the `AuthNeeded` token (e.g. `GetFolderChangeDigest failed: AuthNeeded`). This PR keys on that instead.

## Changes

**`public/unread-number-observer.js`**
- Remove the DOM/timer login heuristic (`isLoggedIn` / `lastLoggedInAt` / `no-inbox`).
- Detect a genuinely expired session from an `unhandledrejection` carrying the `AuthNeeded` token. Require 2 hits within 20s so a transient token refresh does not fire.
- Detect a hard redirect to a Microsoft sign-in page, confirmed after 8s so an SSO bounce during load does not false-fire.
- Notify only. Never auto-reload: silent SSO has already failed, so a reload would loop or wipe a half-entered login (the in-page banner has its own Sign in button).
- Export the pure helpers under a `typeof window` guard so Node can unit-test them.

**`src/controller/mail-window-controller.js`**
- Replace the retry-cap / cooldown / `did-navigate`-reset machinery with a notify-only `report-login-required` handler.
- Add `did-fail-load` network recovery: reload once (debounced) only on transient connectivity net errors, distinct from a login problem.
- Remove the now-unused `OUTLOOK_URL_PATTERNS`.

**Tests + CI**
- `test/login-detection.test.js`: 10 unit tests via Node's built-in `node:test` (no new dependency). Covers pure helpers, Mail/Calendar/Contacts staying silent, single vs repeated `AuthNeeded`, and persistent vs transient sign-in page.
- `package.json`: add `"test": "node --test"`.
- `.github/workflows/test.yml`: run tests on push and pull_request.
- `.github/workflows/build-release.yml`: gate the build matrix on a passing `test` job.

**Docs**
- Add Developer Tools debugging instructions to the bug report template and CONTRIBUTING.

## How to review/test

1. `npm test` (all 10 pass).
2. Launch the app: settings load, observer injects, Outlook reaches the inbox, no false `[LoginRequired]` reload.
3. Feedback from affected users across locales/distros would help confirm.

Closes #428
