### PR TITLE
feat: add custom app icon chooser to the tray menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ For other distributions please follow your specific steps.
 - Start minimized: toggle via tray icon Settings menu, or use command-line
 flag `prospect-mail --minimized`
 - Dock tray support
+- Custom app icon: tray icon → "App Icon" → "Choose App Icon…" (any PNG; also
+  applies to the window icon on Windows/Linux and the dock on macOS)
 - System notification
 - Connect to standard or custom Outlook URL
 - Spellcheck using native Outlook MS Editor
@@ -111,6 +113,7 @@ need to click in "Reload settings" to apply changes.
   "startupWindowState": "normal",
   "showUnreadNotifications": true,
   "unreadNotificationSource": "inbox",
+  "appIcon": "",
   "customBrowserPath": "microsoft-edge"
 }
 ```
@@ -129,6 +132,7 @@ need to click in "Reload settings" to apply changes.
 | `startupWindowState`| Window state on startup: `"normal"`, `"minimized"`, or `"maximized"` (also available via tray menu; `--minimized` flag forces minimized) | `"normal"`     |
 | `showUnreadNotifications` | Show the "new messages" desktop notification (calendar reminders are unaffected; also available via tray menu) | `true`                  |
 | `unreadNotificationSource` | Which folders drive the unread badge and new-mail notifications: `"inbox"` (Inbox only) or `"favorites"` (sum of unread across your Outlook Favorites) | `"inbox"`     |
+| `appIcon`           | Absolute path to a custom PNG for the tray icon, the window icon on Windows/Linux and the dock on macOS (also available via tray menu → App Icon). Empty uses the bundled icons | `""`      |
 | `customBrowserPath` | Custom browser for external links. Use command name (e.g., `"firefox"`) or full path        | System default                    |
 
 > [!NOTE]

--- a/src/app-icon.js
+++ b/src/app-icon.js
@@ -1,0 +1,93 @@
+const path = require("path");
+const { nativeImage } = require("electron");
+const settings = require("./settings");
+
+const macOS = process.platform === "darwin";
+const ASSETS_DIR = path.join(__dirname, "../assets");
+
+// Tray assets per platform and unread state. The macOS pair is monochrome and
+// is used as a template image so it follows the menu bar theme; both macOS
+// files have @2x siblings that nativeImage picks up automatically.
+const TRAY_ICONS = macOS
+  ? { read: "outlook_macOS.png", unread: "outlook_macOS_unread.png" }
+  : { read: "outlook_linux_black.png", unread: "outlook_linux_unread.png" };
+
+// The window icon has never been platform-specific: the full-colour 64x64
+// asset is what BrowserWindow uses everywhere.
+const WINDOW_ICON = "outlook_linux_black.png";
+
+// macOS menu bar height; a custom icon is arbitrary artwork and has to be
+// shrunk to fit, unlike the 16px default assets.
+const MAC_TRAY_SIZE = 16;
+// The macOS dock renders large; anything smaller than this looks blurry.
+const MIN_DOCK_SIZE = 128;
+
+/**
+ * The custom icon path as configured, without checking that it still resolves
+ * to an image. Use this to decide whether the user has set a custom icon at
+ * all (e.g. to enable "Reset to Default Icon"), so that a path which has gone
+ * stale can still be cleared from the menu.
+ */
+function getConfiguredIconPath() {
+  const custom = settings.get("appIcon");
+  return typeof custom === "string" ? custom.trim() : "";
+}
+
+function hasCustomIcon() {
+  return getConfiguredIconPath() !== "";
+}
+
+/**
+ * The custom icon path, but only if it can actually be read as an image. A
+ * file that was deleted or moved since it was picked must fall back to the
+ * bundled icon rather than blank the tray.
+ */
+function getUsableIconPath() {
+  const custom = getConfiguredIconPath();
+  if (!custom) return "";
+  if (nativeImage.createFromPath(custom).isEmpty()) {
+    console.warn(`Custom app icon could not be read, using default: ${custom}`);
+    return "";
+  }
+  return custom;
+}
+
+/** Tray image for the current unread state, honouring a custom icon. */
+function getTrayIcon(isUnread) {
+  const custom = getUsableIconPath();
+  if (custom) {
+    const image = nativeImage.createFromPath(custom);
+    // Keep the user's own colours (no template image, which would flatten the
+    // icon to a mask) and only scale it down for the macOS menu bar.
+    return macOS
+      ? image.resize({ width: MAC_TRAY_SIZE, height: MAC_TRAY_SIZE })
+      : image;
+  }
+
+  const image = nativeImage.createFromPath(
+    path.join(ASSETS_DIR, isUnread ? TRAY_ICONS.unread : TRAY_ICONS.read)
+  );
+  if (macOS) image.setTemplateImage(true);
+  return image;
+}
+
+/** Window icon path (Windows/Linux only), honouring a custom icon. */
+function getWindowIconPath() {
+  return getUsableIconPath() || path.join(ASSETS_DIR, WINDOW_ICON);
+}
+
+/** macOS dock image for the custom icon, upscaled if the file is small. */
+function getDockIcon() {
+  const image = nativeImage.createFromPath(getWindowIconPath());
+  return image.getSize().width < MIN_DOCK_SIZE
+    ? image.resize({ width: MIN_DOCK_SIZE, height: MIN_DOCK_SIZE })
+    : image;
+}
+
+module.exports = {
+  getConfiguredIconPath,
+  hasCustomIcon,
+  getTrayIcon,
+  getWindowIconPath,
+  getDockIcon,
+};

--- a/src/controller/mail-window-controller.js
+++ b/src/controller/mail-window-controller.js
@@ -1,6 +1,14 @@
-const { app, BrowserWindow, shell, ipcMain, Menu } = require("electron");
+const {
+  app,
+  BrowserWindow,
+  shell,
+  ipcMain,
+  Menu,
+  nativeImage,
+} = require("electron");
 const { spawn } = require("child_process");
 const settings = require("../settings");
+const appIcon = require("../app-icon");
 const getClientFile = require("./client-injector");
 const path = require("path");
 
@@ -162,7 +170,7 @@ class MailWindowController {
 
       show: false,
       title: "Prospect Mail",
-      icon: path.join(__dirname, "../../assets/outlook_linux_black.png"),
+      icon: appIcon.getWindowIconPath(),
       webPreferences: {
         contextIsolation: true,
         preload: path.join(__dirname, "preload.js"),
@@ -177,6 +185,10 @@ class MailWindowController {
     // Set true right before a silent recovery reload so the dom-ready handler
     // doesn't re-show a hidden/background window (see reloadWindowSilently).
     this.suppressReloadShow = false;
+
+    // Only when a custom icon is configured: with none, the window icon above
+    // is already right and the dock must keep the icon from the app bundle.
+    if (appIcon.hasCustomIcon()) this.updateAppIcon();
 
     const isDev = process.env.NODE_ENV === "development" || !app.isPackaged;
 
@@ -305,7 +317,7 @@ class MailWindowController {
 
     // Native notification handler
     ipcMain.on("show-notification", (_event, { title, body, icon }) => {
-      const { Notification, nativeImage } = require("electron");
+      const { Notification } = require("electron");
 
       // Check if notifications are supported
       if (!Notification.isSupported()) {
@@ -585,6 +597,24 @@ class MailWindowController {
     });
     notification.on("click", () => this.show());
     notification.show();
+  }
+
+  /**
+   * Applies the current app icon (custom or bundled) to the window and, on
+   * macOS, to the dock. Called at startup and whenever the icon is changed
+   * from the tray menu's "App Icon" submenu.
+   */
+  updateAppIcon() {
+    if (this.win && !this.win.isDestroyed()) {
+      // A no-op on macOS, where the dock icon below *is* the app icon.
+      this.win.setIcon(nativeImage.createFromPath(appIcon.getWindowIconPath()));
+    }
+    if (!app.dock) return;
+    // An empty image restores the icon from the app bundle, which is the right
+    // macOS default: the assets used above are 16-64px tray artwork.
+    app.dock.setIcon(
+      appIcon.hasCustomIcon() ? appIcon.getDockIcon() : nativeImage.createEmpty()
+    );
   }
 
   toggleWindow() {

--- a/src/controller/tray-controller.js
+++ b/src/controller/tray-controller.js
@@ -8,11 +8,10 @@ const {
   shell,
 } = require("electron");
 const settings = require("../settings");
+const appIcon = require("../app-icon");
 const path = require("path");
 const fs = require("fs");
 const { openAboutWindow } = require("./about-window");
-
-const macOS = process.platform === "darwin";
 
 // Electron is pinned to 42.x (Chromium 148) in package.json. Electron 43+ changed
 // the tray D-Bus path/name in ways snapd's unity7 AppArmor template denies, so the
@@ -116,6 +115,22 @@ class TrayController {
         ],
       },
 
+      {
+        label: "App Icon",
+        submenu: [
+          {
+            // Trailing ellipsis (HIG convention): opens a file picker.
+            label: "Choose App Icon…",
+            click: () => this.chooseAppIcon(),
+          },
+          {
+            label: "Reset to Default Icon",
+            enabled: appIcon.hasCustomIcon(),
+            click: () => this.resetAppIcon(),
+          },
+        ],
+      },
+
       { type: "separator" },
       {
         label: "About Prospect Mail",
@@ -128,27 +143,49 @@ class TrayController {
   }
 
   createTrayIcon(value) {
-    const isUnread = Boolean(value);
-    let iconPath;
+    return appIcon.getTrayIcon(Boolean(value));
+  }
 
-    if (macOS) {
-      iconPath = isUnread
-        ? "../../assets/outlook_macOS_unread.png"
-        : "../../assets/outlook_macOS.png";
+  /**
+   * Lets the user pick a PNG to use as the app icon, replacing the bundled
+   * tray, window and dock icons.
+   */
+  chooseAppIcon() {
+    const parentWindow = this.mailController.win;
+    const result = dialog.showOpenDialogSync(parentWindow, {
+      title: "Choose App Icon",
+      filters: [{ name: "Images", extensions: ["png"] }],
+      properties: ["openFile"],
+    });
+    if (!result || result.length === 0) return;
 
-      const trayIcon = nativeImage.createFromPath(
-        path.join(__dirname, iconPath)
-      );
-      trayIcon.setTemplateImage(true);
-      return trayIcon;
+    const selectedPath = result[0];
+    // Reject anything Electron cannot decode before storing it, so a bad pick
+    // can never leave the tray without an icon.
+    if (nativeImage.createFromPath(selectedPath).isEmpty()) {
+      dialog.showMessageBoxSync(parentWindow, {
+        type: "error",
+        title: "Choose App Icon",
+        message: "That file could not be read as an image.",
+        detail: selectedPath,
+      });
+      return;
     }
 
-    // For non-macOS platforms
-    iconPath = isUnread
-      ? "../../assets/outlook_linux_unread.png"
-      : "../../assets/outlook_linux_black.png";
+    settings.set("appIcon", selectedPath);
+    this.applyAppIcon();
+  }
 
-    return nativeImage.createFromPath(path.join(__dirname, iconPath));
+  resetAppIcon() {
+    settings.set("appIcon", "");
+    this.applyAppIcon();
+  }
+
+  applyAppIcon() {
+    this.tray.setImage(this.createTrayIcon(this.lastUnread));
+    this.mailController.updateAppIcon();
+    // Rebuild so "Reset to Default Icon" reflects the new state
+    this.buildContextMenu();
   }
 
   fireClickEvent() {

--- a/src/settings.js
+++ b/src/settings.js
@@ -46,6 +46,10 @@ const settings = new Store({
     //   "inbox"     — the Inbox folder only (default, original behaviour)
     //   "favorites" — sum of unread across the Outlook Favorites folders
     unreadNotificationSource: "inbox",
+    // Absolute path to a custom PNG used for the tray icon, the window icon on
+    // Windows/Linux and the dock on macOS. Empty means the bundled icons are
+    // used; also settable from the tray menu's "App Icon" submenu.
+    appIcon: "",
     customBrowserPath: undefined
   }
 });


### PR DESCRIPTION
Adds an "App Icon" submenu to the tray context menu with "Choose App Icon…" and "Reset to Default Icon". 
The chosen PNG replaces the tray icon, the window icon on Windows/Linux and the dock icon on macOS. 
It is applied live - no restart - and persisted as the new `appIcon` setting, so it can also be set by editing settings.json.

Icon resolution moves into src/app-icon.js so the tray controller and the window controller share one source of truth for which icon is current. 
A configured path that no longer resolves to an image (file deleted or moved) falls back to the bundled icons instead of leaving the tray blank, while still counting as "custom" so the reset entry stays available. 
A picked file is validated before it is stored, so a bad pick cannot blank the tray either.

<img width="396" height="228" alt="tray_menu" src="https://github.com/user-attachments/assets/c5b16225-6e90-4968-9415-b04b1b321a66" />
<img width="238" height="253" alt="custom_icon" src="https://github.com/user-attachments/assets/3d9a25c8-48ee-4ea0-833a-4b5872a3844e" />

[PR-ADDENDUM.md](https://github.com/user-attachments/files/31732221/PR-ADDENDUM.md)

This is my very first pull request, so please tell me if anything about the structure or conventions should be different — happy to adjust!